### PR TITLE
Undefined nodes, groups and links in new tapestry created from wp

### DIFF
--- a/controller/class.tapestry-controller.php
+++ b/controller/class.tapestry-controller.php
@@ -357,6 +357,11 @@ class TapestryController
         }
 
         $tapestry = get_post_meta($this->postId, 'tapestry', true);
+
+        if (!isset($tapestry->nodes)) {
+            return [];
+        }
+
         return $tapestry->nodes;
     }
 
@@ -494,15 +499,6 @@ class TapestryController
 
     private function _filterTapestry($tapestry)
     {
-        if ((!TapestryUserRoles::isEditor())
-            && (!TapestryUserRoles::isAdministrator()
-                && (!TapestryUserRoles::isAuthorOfThePost($this->postId)))
-        ) {
-            $tapestry->nodes = $this->_filterNodeMetaIdsByPermissions($tapestry->nodes);
-            $tapestry->links = $this->_filterLinksByNodeMetaIds($tapestry->links, $tapestry->nodes);
-            $tapestry->groups = $this->_getGroupIdsOfUser(wp_get_current_user()->ID);
-        }
-
         if (!isset($tapestry->nodes)) {
             $tapestry->nodes = [];
         }
@@ -513,6 +509,15 @@ class TapestryController
 
         if (!isset($tapestry->groups)) {
             $tapestry->groups = [];
+        }
+
+        if ((!TapestryUserRoles::isEditor())
+            && (!TapestryUserRoles::isAdministrator()
+                && (!TapestryUserRoles::isAuthorOfThePost($this->postId)))
+        ) {
+            $tapestry->nodes = $this->_filterNodeMetaIdsByPermissions($tapestry->nodes);
+            $tapestry->links = $this->_filterLinksByNodeMetaIds($tapestry->links, $tapestry->nodes);
+            $tapestry->groups = $this->_getGroupIdsOfUser(wp_get_current_user()->ID);
         }
 
         return $tapestry;


### PR DESCRIPTION
The reason those errors were undetected is that I had an older version of Wordpress, which is more tolerant on undefined values in objects.

Updated to the latest WP version and fixed the bugs.

Fixes #59 