### PR TITLE
Add empty arrays for nodes groups and links

### DIFF
--- a/controller/class.tapestry-controller.php
+++ b/controller/class.tapestry-controller.php
@@ -357,6 +357,11 @@ class TapestryController
         }
 
         $tapestry = get_post_meta($this->postId, 'tapestry', true);
+
+        if (!isset($tapestry->nodes)) {
+            return [];
+        }
+
         return $tapestry->nodes;
     }
 
@@ -494,15 +499,6 @@ class TapestryController
 
     private function _filterTapestry($tapestry)
     {
-        if ((!TapestryUserRoles::isEditor())
-            && (!TapestryUserRoles::isAdministrator()
-                && (!TapestryUserRoles::isAuthorOfThePost($this->postId)))
-        ) {
-            $tapestry->nodes = $this->_filterNodeMetaIdsByPermissions($tapestry->nodes);
-            $tapestry->links = $this->_filterLinksByNodeMetaIds($tapestry->links, $tapestry->nodes);
-            $tapestry->groups = $this->_getGroupIdsOfUser(wp_get_current_user()->ID);
-        }
-
         if (!isset($tapestry->nodes)) {
             $tapestry->nodes = [];
         }
@@ -513,6 +509,15 @@ class TapestryController
 
         if (!isset($tapestry->groups)) {
             $tapestry->groups = [];
+        }
+
+        if ((!TapestryUserRoles::isEditor())
+            && (!TapestryUserRoles::isAdministrator()
+                && (!TapestryUserRoles::isAuthorOfThePost($this->postId)))
+        ) {
+            $tapestry->nodes = $this->_filterNodeMetaIdsByPermissions($tapestry->nodes);
+            $tapestry->links = $this->_filterLinksByNodeMetaIds($tapestry->links, $tapestry->nodes);
+            $tapestry->groups = $this->_getGroupIdsOfUser(wp_get_current_user()->ID);
         }
 
         return $tapestry;

--- a/controller/class.tapestry-controller.php
+++ b/controller/class.tapestry-controller.php
@@ -270,7 +270,6 @@ class TapestryController
 
         if (empty($tapestry)) {
             $tapestry =  (object)array(
-                'settings'  => $settings,
                 'nodes'     => [],
                 'groups'    => [],
                 'links'     => []

--- a/controller/class.tapestry-controller.php
+++ b/controller/class.tapestry-controller.php
@@ -268,8 +268,13 @@ class TapestryController
 
         $tapestry = get_post_meta($this->postId, 'tapestry', true);
 
-        if (!isset($tapestry)) {
-            $tapestry =  (object)array();
+        if (empty($tapestry)) {
+            $tapestry =  (object)array(
+                'settings'  => $settings,
+                'nodes'     => [],
+                'groups'    => [],
+                'links'     => []
+            );
         }
 
         $tapestry->settings = $settings;


### PR DESCRIPTION
In order to make sure all the fields exist when a tapestry is created from the Wordpress interface, I added empty arrays for nodes, groups and links so that it **no longer** breaks the frontend.

My apologies for such bugs like this due to older WP version. 

Fixes #64 