### PR TITLE
Fix for saving and retrieving unlocked node per user

### DIFF
--- a/controller/class.tapestry-controller.php
+++ b/controller/class.tapestry-controller.php
@@ -301,39 +301,6 @@ class TapestryController
     }
 
     /**
-     * Update Tapestry Node Unlocked Status
-     * 
-     * @param   Integer $nodeMetaId     Node meta id
-     * @param   Boolean $unlocked       Node unlocked status
-     *
-     * @return  Boolean $unlocked
-     */
-    public function updateTapestryNodeUnlockedStatus($nodeMetaId, $unlocked)
-    {
-        if (!$this->postId) {
-            return $this->_throwsError('INVALID_POST_ID');
-        }
-        if (!$this->_isValidTapestryNode($nodeMetaId)) {
-            return $this->_throwsError('INVALID_NODE_META_ID');
-        }
-        if (!$this->_isChildNodeOfTapestry($nodeMetaId)) {
-            return $this->_throwsError('INVALID_CHILD_NODE');
-        }
-        if (!$this->_currentUserIsAllowed('EDIT', $nodeMetaId)) {
-            return $this->_throwsError('EDIT_NODE_PERMISSION_DENIED');
-        }
-
-        // TODO: Verify that this is a boolean
-
-        $nodeMetadata = get_metadata_by_mid('post', $nodeMetaId)->meta_value;
-        $nodeMetadata->unlocked = $unlocked;
-
-        update_metadata_by_mid('post', $nodeMetaId, $nodeMetadata);
-
-        return $unlocked;
-    }
-
-    /**
      * Update Tapestry Node Type Data
      * 
      * @param   Integer $nodeMetaId     Node meta id

--- a/controller/class.user-controller.php
+++ b/controller/class.user-controller.php
@@ -131,9 +131,9 @@ class TapestryUserController
             $default_unlocked_status = $nodeMetadata->unlocked ? true : false;
             $unlocked_value = get_user_meta($this->_userId, 'tapestry_' . $postId . '_node_unlocked_' . $nodeId, true);
             if ($unlocked_value !== null) {
-                $progress->$nodeId->$unlocked = $unlocked_value;
+                $progress->$nodeId->unlocked = $unlocked_value;
             } else {
-                $progress->$nodeId->$unlocked = $default_unlocked_status;
+                $progress->$nodeId->unlocked = $default_unlocked_status;
             }
         }
 

--- a/controller/class.user-controller.php
+++ b/controller/class.user-controller.php
@@ -41,6 +41,20 @@ class TapestryUserController
     }
 
     /**
+     * Set 'unlocked' status of a Tapestry Node for this User to true
+     *
+     * @param Integer $postId the post's ID
+     * @param Integer $nodeId the node's ID to be unlocked
+     *
+     * @return Null
+     */
+    public function unlockNode($postId, $nodeId) 
+    {
+        $this->_checkUserAndPostId($postId);
+        $this->_unlockNode($postId, $nodeId);
+    }
+
+    /**
      * Get User's video progress for a tapestry post
      *
      * @param Integer $postId    the post's ID
@@ -94,6 +108,11 @@ class TapestryUserController
         update_user_meta($this->_userId, 'tapestry_' . $postId . '_progress_node_' . $nodeId, $progressValue);
     }
 
+    private function _unlockNode($postId, $nodeId) 
+    {
+        update_user_meta($this->_userId, 'tapestry_' . $postId . '_node_unlocked_' . $nodeId, true);
+    }
+
     private function _getUserProgress($postId, $nodeIdArr) 
     {
         $progress = new stdClass();
@@ -101,10 +120,20 @@ class TapestryUserController
         // Build json object for frontend e.g. {0: 0.1, 1: 0.2} where 0 and 1 are the node IDs
         foreach ($nodeIdArr as $nodeId) {
             $progress_value = get_user_meta($this->_userId, 'tapestry_' . $postId . '_progress_node_' . $nodeId, true);
+            $progress->$nodeId = new stdClass();
             if ($progress_value !== null) {
-                $progress->$nodeId = (float) $progress_value;
+                $progress->$nodeId->progress = (float) $progress_value;
             } else {
-                $progress->$nodeId = 0.0;
+                $progress->$nodeId->progress = 0;
+            }
+
+            $nodeMetadata = get_metadata_by_mid('post', $nodeId)->meta_value;
+            $default_unlocked_status = $nodeMetadata->unlocked ? true : false;
+            $unlocked_value = get_user_meta($this->_userId, 'tapestry_' . $postId . '_node_unlocked_' . $nodeId, true);
+            if ($unlocked_value !== null) {
+                $progress->$nodeId->$unlocked = $unlocked_value;
+            } else {
+                $progress->$nodeId->$unlocked = $default_unlocked_status;
             }
         }
 

--- a/endpoints.php
+++ b/endpoints.php
@@ -73,14 +73,6 @@ $REST_API_ENDPOINTS = [
             'permission_callback'   => 'TapestryPermissions::putTapestryNodeProperties'
         ]
     ],
-    'PUT_TAPESTRY_NODE_UNLOCKED_STATUS' => (object)[
-        'ROUTE'     => '/tapestries/(?P<tapestryPostId>[\d]+)/nodes/(?P<nodeMetaId>[\d]+)/unlocked',
-        'ARGUMENTS' => [
-            'methods'               => 'PUT',
-            'callback'              => 'updateTapestryNodeUnlockedStatus',
-            'permission_callback'   => 'TapestryPermissions::putTapestryNodeProperties'
-        ]
-    ],
     'PUT_TAPESTRY_NODE_TYPE_DATA' => (object)[
         'ROUTE'     => '/tapestries/(?P<tapestryPostId>[\d]+)/nodes/(?P<nodeMetaId>[\d]+)/typeData',
         'ARGUMENTS' => [
@@ -117,6 +109,13 @@ $REST_API_ENDPOINTS = [
         'ARGUMENTS' => [
             'methods'               => 'POST',
             'callback'              => 'updateProgressByNodeId',
+        ]
+    ],
+    'UPDATE_TAPESTRY_UNLOCKED' => (object)[
+        'ROUTE'     => 'users/unlocked',
+        'ARGUMENTS' => [
+            'methods'               => 'POST',
+            'callback'              => 'unlockByNodeId',
         ]
     ],
     'GET_H5P_SETTING' => (object)[
@@ -286,24 +285,6 @@ function updateTapestryNodeImageURL($request)
 }
 
 /**
- * Update Tapestry Node Unlocked Status
- * 
- * @param   Object  $request    HTTP request
- * 
- * @return  Object  $response   HTTP response
- */
-function updateTapestryNodeUnlockedStatus($request)
-{
-    $postId = $request['tapestryPostId'];
-    $nodeMetaId = $request['nodeMetaId'];
-    $data = json_decode($request->get_body());
-    // TODO: JSON validations should happen here
-    // make sure the unlocked status exists and not null
-    $tapestryController = new TapestryController($postId);
-    return $tapestryController->updateTapestryNodeUnlockedStatus($nodeMetaId, $data);
-}
-
-/**
  * Update Tapestry Node Type Data
  * 
  * @param   Object  $request    HTTP request
@@ -388,6 +369,21 @@ function updateProgressByNodeId($request)
     $nodeId = $request['node_id'];
     $progressValue = $request['progress_value'];
     $userController->updateProgress($postId, $nodeId, $progressValue);
+}
+
+/**
+ * Set unlocked status of a single node to true by passing in node id and post id
+ * Example: /wp-json/tapestry-tool/v1/users/unlocked?post_id=44&node_id=1
+ * 
+ * @param Object $request HTTP request
+ * @return null
+ */
+function unlockByNodeId($request)
+{
+    $userController = new TapestryUserController;
+    $postId = $request['post_id'];
+    $nodeId = $request['node_id'];
+    $userController->unlockNode($postId, $nodeId);
 }
 
 /**


### PR DESCRIPTION
- Remove tapestry node unlocked functionality/endpoints since it should be related to the user
- Add endpoint and related functions for setting user node to unlocked
- Retrieve and return user node unlocked status with node progress