### PR TITLE
Save and retrieve unlocked node per user and fix progress saving

### DIFF
--- a/classes/class.tapestry-user-progress.php
+++ b/classes/class.tapestry-user-progress.php
@@ -29,29 +29,6 @@ class TapestryUserProgress implements ITapestryUserProgress
     }
 
     /**
-     * Update User's video progress for a tapestry post
-     *
-     * @param Float   $progressValue how much the video was viewed, value should be between >= 0 and <= 1
-     *
-     * @return Null
-     */
-    public function save($progressValue)
-    {
-        $this->_checkUserAndPostId();
-
-        if ($progressValue !== null) {
-            $progressValue = floatval($progressValue);
-        }
-
-        // Value should be between 0 and 1
-        if ($progressValue < 0 || $progressValue > 1) {
-            throw new Exception('Invalid progress value');
-        }
-
-        $this->_updateUserProgress($progressValue);
-    }
-
-    /**
      * Get User's video progress for a tapestry post
      *
      * @return String progress   of each node in json format
@@ -68,12 +45,46 @@ class TapestryUserProgress implements ITapestryUserProgress
     }
 
     /**
+     * Update User's video progress for a tapestry post
+     *
+     * @param Float $progressValue how much the video was viewed, value should be between >= 0 and <= 1
+     *
+     * @return Null
+     */
+    public function updateUserProgress($progressValue)
+    {
+        $this->_checkUserAndPostId();
+
+        if ($progressValue !== null) {
+            $progressValue = floatval($progressValue);
+        }
+
+        // Value should be between 0 and 1
+        if ($progressValue < 0 || $progressValue > 1) {
+            throw new Exception('Invalid progress value');
+        }
+
+        $this->_updateUserProgress($progressValue);
+    }
+
+    /**
+     * Set 'unlocked' status of a Tapestry Node for this User to true
+     *
+     * @return Null
+     */
+    public function unlockNode() 
+    {
+        $this->_checkUserAndPostId();
+        $this->_unlockNode();
+    }
+
+    /**
      * Update User's h5p video setting for a tapestry post
      *
      * @param   String  $h5pSettingsData stores volume,
      * playbackRate, quality of h5p video
      * 
-     * @return  NULL
+     * @return  Null
      */
     public function updateH5PSettings($h5pSettingsData)
     {
@@ -91,7 +102,7 @@ class TapestryUserProgress implements ITapestryUserProgress
     /**
      * Get User's h5p video setting for a tapestry post
      * 
-     * @return String h5p   $setting
+     * @return String h5p $setting
      */
     public function getH5PSettings()
     {
@@ -102,29 +113,15 @@ class TapestryUserProgress implements ITapestryUserProgress
 
     private function _updateUserProgress($progressValue)
     {
-        update_user_meta($this->_userId, 'tapestry_' . $this->postId . '_progress_node_' . $this->nodeId, $progressValue);
+        update_user_meta($this->_userId, 'tapestry_' . $this->postId . '_progress_node_' . $this->nodeMetaId, $progressValue);
     }
 
-    /**
-     * Set 'unlocked' status of a Tapestry Node for this User to true
-     *
-     * @param Integer $postId the post's ID
-     * @param Integer $nodeId the node's ID to be unlocked
-     *
-     * @return Null
-     */
-    public function unlockNode($postId, $nodeId) 
+    private function _unlockNode() 
     {
-        $this->_checkUserAndPostId($postId);
-        $this->_unlockNode($postId, $nodeId);
+        update_user_meta($this->_userId, 'tapestry_' . $this->postId . '_node_unlocked_' . $this->nodeMetaId, true);
     }
 
-    private function _unlockNode($postId, $nodeId) 
-    {
-        update_user_meta($this->_userId, 'tapestry_' . $postId . '_node_unlocked_' . $nodeId, true);
-    }
-
-    private function _getUserProgress($postId,$nodeIdArr)
+    private function _getUserProgress($nodeIdArr)
     {
         $progress = new stdClass();
 
@@ -139,8 +136,8 @@ class TapestryUserProgress implements ITapestryUserProgress
             }
 
             $nodeMetadata = get_metadata_by_mid('post', $nodeId)->meta_value;
-            $default_unlocked_status = $nodeMetadata->unlocked ? true : false;
-            $unlocked_value = get_user_meta($this->_userId, 'tapestry_' . $postId . '_node_unlocked_' . $nodeId, true);
+            $default_unlocked_status = isset($nodeMetadata->unlocked) && $nodeMetadata->unlocked ? true : false;
+            $unlocked_value = get_user_meta($this->_userId, 'tapestry_' . $this->postId . '_node_unlocked_' . $nodeId, true);
             if ($unlocked_value !== null) {
                 $progress->$nodeId->unlocked = $unlocked_value;
             } else {

--- a/endpoints.php
+++ b/endpoints.php
@@ -84,13 +84,6 @@ $REST_API_ENDPOINTS = [
             'permission_callback'   => 'TapestryPermissions::putTapestryNodeProperties'
         ]
     ],
-    'UPDATE_TAPESTRY_UNLOCKED' => (object)[
-        'ROUTE'     => 'users/unlocked',
-        'ARGUMENTS' => [
-            'methods'               => 'POST',
-            'callback'              => 'unlockByNodeId'
-        ]
-    ],
     'PUT_TAPESTRY_NODE_TYPE_DATA' => (object) [
         'ROUTE'     => '/tapestries/(?P<tapestryPostId>[\d]+)/nodes/(?P<nodeMetaId>[\d]+)/typeData',
         'ARGUMENTS' => [
@@ -115,28 +108,35 @@ $REST_API_ENDPOINTS = [
             'permission_callback'   => 'TapestryPermissions::postTapestryLink'
         ]
     ],
-    'GET_TAPESTRY_PROGRESS' => (object) [
+    'GET_TAPESTRY_USER_PROGRESS' => (object) [
         'ROUTE'     => 'users/progress',
         'ARGUMENTS' => [
             'methods'               => 'GET',
             'callback'              => 'getUserProgressByPostId',
         ]
     ],
-    'UPDATE_TAPESTRY_PROGRESS' => (object) [
+    'UPDATE_TAPESTRY_USER_PROGRESS' => (object) [
         'ROUTE'     => 'users/progress',
         'ARGUMENTS' => [
             'methods'               => 'POST',
             'callback'              => 'updateProgressByNodeId',
         ]
     ],
-    'GET_H5P_SETTING' => (object) [
+    'UPDATE_TAPESTRY_USER_UNLOCKED' => (object)[
+        'ROUTE'     => 'users/unlocked',
+        'ARGUMENTS' => [
+            'methods'               => 'POST',
+            'callback'              => 'unlockByNodeId'
+        ]
+    ],
+    'GET_TAPESTRY_USER_H5P_SETTING' => (object) [
         'ROUTE'     => 'users/h5psettings',
         'ARGUMENTS' => [
             'methods'               => 'GET',
             'callback'              => 'getUserU5PSettingsByPostId',
         ]
     ],
-    'UPDATE_H5P_SETTING' => (object) [
+    'UPDATE_TAPESTRY_USER_H5P_SETTING' => (object) [
         'ROUTE'     => 'users/h5psettings',
         'ARGUMENTS' => [
             'methods'               => 'POST',
@@ -159,6 +159,24 @@ foreach ($REST_API_ENDPOINTS as $ENDPOINT) {
             );
         }
     );
+}
+
+/**
+ * Get a Tapestry
+ * 
+ * @param Object $request HTTP request
+ * 
+ * @return Object $response HTTP response
+ */
+function getTapestry($request)
+{
+    $postId = $request['tapestryPostId'];
+    try {
+        $tapestry = new Tapestry($postId);
+        return $tapestry->get();
+    } catch (TapestryError $e) {
+        return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
+    }
 }
 
 /**
@@ -439,22 +457,6 @@ function updateTapestryNodeImageURL($request)
     }
 }
 
-/**
- * Set unlocked status of a single node to true by passing in node id and post id
- * Example: /wp-json/tapestry-tool/v1/users/unlocked?post_id=44&node_id=1
- * 
- * @param Object $request HTTP request
- * 
- * @return null
- */
-function unlockByNodeId($request)
-{
-    $userController = new TapestryUserController;
-    $postId = $request['post_id'];
-    $nodeId = $request['node_id'];
-    $userController->unlockNode($postId, $nodeId);
-}
-
 /** 
  * Update Tapestry Node Type Data
  * 
@@ -532,7 +534,7 @@ function updateTapestryNodeCoordinates($request)
 }
 
 /**
- * Update a single node progress by passing in node id, post id and progress value
+ * Update a single node progress for the current user by passing in node id, post id and progress value
  * Example: /wp-json/tapestry-tool/v1/users/progress?post_id=44&node_id=1&progress_value=0.2
  * 
  * @param Object $request HTTP request
@@ -546,7 +548,28 @@ function updateProgressByNodeId($request)
 
     try {
         $userProgress = new TapestryUserProgress($postId, $nodeMetaId);
-        $userProgress->save($progressValue);
+        $userProgress->updateUserProgress($progressValue);
+    } catch (TapestryError $e) {
+        return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
+    }
+}
+
+/**
+ * Set unlocked status of a single node for the current user to true by passing in node id and post id
+ * Example: /wp-json/tapestry-tool/v1/users/unlocked?post_id=44&node_id=1
+ * 
+ * @param Object $request HTTP request
+ * 
+ * @return null
+ */
+function unlockByNodeId($request)
+{
+    $postId = $request['post_id'];
+    $nodeMetaId = $request['node_id'];
+
+    try {
+        $userProgress = new TapestryUserProgress($postId, $nodeMetaId);
+        $userProgress->unlockNode();
     } catch (TapestryError $e) {
         return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
     }
@@ -587,24 +610,6 @@ function updateUserH5PSettingsByPostId($request)
     try {
         $userProgress = new TapestryUserProgress($postId);
         $userProgress->updateH5PSettings($h5pSettingsData);
-    } catch (TapestryError $e) {
-        return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
-    }
-}
-
-/**
- * Get a Tapestry
- * 
- * @param   Object  $request    HTTP request
- * 
- * @return  Object  $response   HTTP response
- */
-function getTapestry($request)
-{
-    $postId = $request['tapestryPostId'];
-    try {
-        $tapestry = new Tapestry($postId);
-        return $tapestry->get();
     } catch (TapestryError $e) {
         return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
     }

--- a/interfaces/interface.tapestry-user-progress.php
+++ b/interfaces/interface.tapestry-user-progress.php
@@ -6,21 +6,29 @@
  */
 interface ITapestryUserProgress
 {
-    /**
-     * Save data
-     * 
-     * @param   Object  $data   data to be saved
-     * 
-     * @return  Object  $data
-     */
-    public function save($data);
 
     /**
-     * Retrieve data
-     * 
-     * @return  Object  $data
+     * Get User's video progress for a tapestry post
+     *
+     * @return String progress of each node in json format
      */
     public function get();
+
+    /**
+     * Update User's video progress for a tapestry post
+     *
+     * @param Float $progressValue how much the video was viewed, value should be between >= 0 and <= 1
+     *
+     * @return Null
+     */
+    public function updateUserProgress($data);
+    
+    /**
+     * Set 'unlocked' status of a Tapestry Node for this User to true
+     *
+     * @return Null
+     */
+    public function unlockNode();
 
     /**
      * Update User's h5p video setting for a tapestry post
@@ -28,14 +36,14 @@ interface ITapestryUserProgress
      * @param   String  $h5pSettingsData stores volume,
      * playbackRate, quality of h5p video
      * 
-     * @return  NULL
+     * @return  Null
      */
     public function updateH5PSettings($h5pSettingsData);
 
     /**
      * Get User's h5p video setting for a tapestry post
      * 
-     * @return String h5p   $setting
+     * @return String h5p $setting
      */
     public function getH5PSettings();
 }

--- a/interfaces/interface.tapestry-user-progress.php
+++ b/interfaces/interface.tapestry-user-progress.php
@@ -21,7 +21,7 @@ interface ITapestryUserProgress
      *
      * @return Null
      */
-    public function updateUserProgress($data);
+    public function updateUserProgress($progressValue);
     
     /**
      * Set 'unlocked' status of a Tapestry Node for this User to true
@@ -33,10 +33,10 @@ interface ITapestryUserProgress
     /**
      * Update User's h5p video setting for a tapestry post
      *
-     * @param   String  $h5pSettingsData stores volume,
+     * @param String $h5pSettingsData stores volume,
      * playbackRate, quality of h5p video
      * 
-     * @return  Null
+     * @return Null
      */
     public function updateH5PSettings($h5pSettingsData);
 


### PR DESCRIPTION
* Create new method for marking a node as unlocked for the current user
* Change `getUserProgress` to return unlocked status in addition to the progress
* Fix a bug causing user progress not to be saved
* Rename user-progress class `save()` method to `updateUserProgress`
* Reorganize the order of methods