### PR TITLE
Add wordpress post as a node type

### DIFF
--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -2222,6 +2222,10 @@ function getIconClass(mediaType, action) {
             classStr = classStrStart + 'window-maximize';
             break;
 
+        case "wp-post":
+            classStr = "fab fa-wordpress-simple";
+            break;
+
         default:
             classStr = classStrStart + 'exclamation';
             break;

--- a/templates/vue/src/components/Lightbox.vue
+++ b/templates/vue/src/components/Lightbox.vue
@@ -9,7 +9,13 @@
       <div
         v-if="isLoaded"
         id="spotlight-content"
-        :class="['content', { 'content-text': node.mediaType === 'text' }]"
+        :class="[
+          'content',
+          {
+            'content-text':
+              node.mediaType === 'text' || node.mediaType === 'wp-post',
+          },
+        ]"
         :style="lightboxContentStyles"
       >
         <button v-if="canSkip" class="close-btn" @click="$emit('close')">

--- a/templates/vue/src/components/Lightbox.vue
+++ b/templates/vue/src/components/Lightbox.vue
@@ -55,6 +55,7 @@
             @complete="complete"
             @close="$emit('close')"
           />
+          <post-media v-if="node.mediaType === 'wp-post'" :node="node" />
         </div>
       </div>
     </transition>
@@ -66,6 +67,7 @@ import TextMedia from "./lightbox/TextMedia"
 import VideoMedia from "./lightbox/VideoMedia"
 import ExternalMedia from "./lightbox/ExternalMedia"
 import H5PMedia from "./lightbox/H5PMedia"
+import PostMedia from "./lightbox/PostMedia"
 import Helpers from "../utils/Helpers"
 import { mapGetters, mapState, mapActions, mapMutations } from "vuex"
 
@@ -77,6 +79,7 @@ export default {
     VideoMedia,
     TextMedia,
     ExternalMedia,
+    PostMedia,
     "h5p-media": H5PMedia,
   },
   props: {

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -53,9 +53,9 @@
             </b-form-group>
             <b-form-group v-show="node.mediaType === 'wp-post'" label="Post Name">
               <combobox
-                v-model="node.typeData.textContent"
+                v-model="node.typeData.mediaURL"
                 item-text="title"
-                item-value="content"
+                item-value="id"
                 empty-message="There are no posts yet. Please add one in your WP dashboard."
                 :options="wpPosts"
               >
@@ -354,6 +354,7 @@ export default {
       h5pContentOptions: [],
       selectedGravityFormContent: "",
       selectedH5pContent: "",
+      selectedWpPost: "",
       wpPosts: [],
       formErrors: "",
       maxDescriptionLength: 250,

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -56,7 +56,7 @@
                 v-model="node.typeData.mediaURL"
                 item-text="title"
                 item-value="id"
-                empty-message="There are no posts yet. Please add one in your WP dashboard."
+                empty-message="There are no Wordpress posts yet. Please add one in your WP dashboard."
                 :options="wpPosts"
               >
                 <template v-slot="slotProps">

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -327,7 +327,7 @@ export default {
         { value: "video", text: "Video" },
         { value: "h5p", text: "H5P" },
         { value: "url-embed", text: "External Link" },
-        { value: "wp-post", text: "Wordpress Post" }
+        { value: "wp-post", text: "Wordpress Post" },
       ],
       h5pContentOptions: [],
       selectedH5pContent: "",

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -51,6 +51,22 @@
                 @change="handleTypeChange"
               ></b-form-select>
             </b-form-group>
+            <b-form-group v-show="node.mediaType === 'wp-post'" label="Post Name">
+              <combobox
+                v-model="node.typeData.textContent"
+                item-text="title"
+                item-value="content"
+                empty-message="There are no posts yet. Please add one in your WP dashboard."
+                :options="wpPosts"
+              >
+                <template v-slot="slotProps">
+                  <p>
+                    <code>{{ slotProps.option.id }}</code>
+                    {{ slotProps.option.title }}
+                  </p>
+                </template>
+              </combobox>
+            </b-form-group>
             <b-form-group v-show="node.mediaType === 'text'" label="Text content">
               <b-form-textarea
                 id="node-text-content"
@@ -268,6 +284,7 @@ import Helpers from "../utils/Helpers"
 import Combobox from "./Combobox"
 import QuizModal from "./node-modal/QuizModal"
 import H5PApi from "../services/H5PApi"
+import WordpressApi from "../services/WordpressApi"
 
 export default {
   name: "node-modal",
@@ -310,9 +327,11 @@ export default {
         { value: "video", text: "Video" },
         { value: "h5p", text: "H5P" },
         { value: "url-embed", text: "External Link" },
+        { value: "wp-post", text: "Wordpress Post" }
       ],
       h5pContentOptions: [],
       selectedH5pContent: "",
+      wpPosts: [],
       formErrors: "",
       maxDescriptionLength: 250,
       addThumbnail: false,
@@ -390,6 +409,7 @@ export default {
   },
   async mounted() {
     this.h5pContentOptions = await H5PApi.getAllContent()
+    this.wpPosts = await WordpressApi.getPosts()
     this.$root.$on("bv::modal::show", (bvEvent, modalId) => {
       if (modalId == "node-modal-container") {
         this.formErrors = ""

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -272,6 +272,9 @@ export default {
             } else if (fieldValue === "url-embed") {
               newNodeEntry["mediaType"] = "url-embed"
               newNodeEntry["mediaFormat"] = "embed"
+            } else {
+              newNodeEntry.mediaType = "wp-post"
+              newNodeEntry.mediaFormat = ""
             }
             break
           case "textContent":

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -215,7 +215,10 @@ export default {
         group: 1,
         typeData: {
           linkMetadata: null,
-          progress: [{ group: "viewed", value: 0 }, { group: "unviewed", value: 1 }],
+          progress: [
+            { group: "viewed", value: 0 },
+            { group: "unviewed", value: 1 },
+          ],
           mediaURL: "",
           mediaWidth: 960, //TODO: This needs to be flexible with H5P
           mediaHeight: 600,

--- a/templates/vue/src/components/TapestryMedia.vue
+++ b/templates/vue/src/components/TapestryMedia.vue
@@ -42,6 +42,7 @@
       :id="node.typeData.mediaURL"
       @submit="handleFormSubmit"
     ></gravity-form>
+    <wp-post-media v-if="node.mediaType === 'wp-post'" :node="node"></wp-post-media>
     <completion-screen v-if="showCompletionScreen" />
   </div>
 </template>
@@ -53,6 +54,7 @@ import VideoMedia from "./lightbox/VideoMedia"
 import ExternalMedia from "./lightbox/ExternalMedia"
 import H5PMedia from "./lightbox/H5PMedia"
 import GravityForm from "./lightbox/GravityForm"
+import WpPostMedia from "./lightbox/WpPostMedia"
 import CompletionScreen from "./lightbox/quiz/CompletionScreen"
 
 const SAVE_INTERVAL = 5
@@ -65,6 +67,7 @@ export default {
     ExternalMedia,
     "h5p-media": H5PMedia,
     GravityForm,
+    WpPostMedia,
     CompletionScreen,
   },
   props: {

--- a/templates/vue/src/components/lightbox/PostMedia.vue
+++ b/templates/vue/src/components/lightbox/PostMedia.vue
@@ -1,15 +1,66 @@
 <template>
-  <article v-html="node.typeData.textContent" />
+  <loading v-if="loading" />
+  <div v-else class="article">
+    <h1 class="article-title">{{ title }}</h1>
+    <article v-html="content"></article>
+  </div>
 </template>
 
 <script>
+import Loading from "../Loading"
+import WordpressApi from "../../services/WordpressApi"
+
 export default {
   name: "post-media",
+  components: {
+    Loading,
+  },
   props: {
     node: {
       type: Object,
       required: true,
     },
   },
+  data() {
+    return {
+      loading: true,
+      title: "",
+      content: "",
+    }
+  },
+  computed: {
+    id() {
+      return this.node.typeData.mediaURL
+    },
+  },
+  async mounted() {
+    const post = await WordpressApi.getPostById(this.id)
+    this.loading = false
+    this.title = post.title
+    this.content = post.content
+  },
 }
 </script>
+
+<style lang="scss" scoped>
+.article {
+  padding: 25px;
+  text-align: left;
+
+  &-title {
+    font-size: 1.75rem;
+    font-weight: bold;
+    margin: 1em 0;
+
+    :before {
+      display: none;
+    }
+  }
+
+  article {
+    color: #47425d;
+    font-family: "Source Sans Pro", sans-serif;
+    font-size: 16px;
+  }
+}
+</style>

--- a/templates/vue/src/components/lightbox/PostMedia.vue
+++ b/templates/vue/src/components/lightbox/PostMedia.vue
@@ -1,0 +1,15 @@
+<template>
+  <article v-html="node.typeData.textContent" />
+</template>
+
+<script>
+export default {
+  name: "post-media",
+  props: {
+    node: {
+      type: Object,
+      required: true,
+    },
+  },
+}
+</script>

--- a/templates/vue/src/components/lightbox/WpPostMedia.vue
+++ b/templates/vue/src/components/lightbox/WpPostMedia.vue
@@ -11,7 +11,7 @@ import Loading from "../Loading"
 import WordpressApi from "../../services/WordpressApi"
 
 export default {
-  name: "post-media",
+  name: "wp-post-media",
   components: {
     Loading,
   },

--- a/templates/vue/src/services/WordpressApi.js
+++ b/templates/vue/src/services/WordpressApi.js
@@ -5,12 +5,21 @@ const API_URL = `${wpData.rest_url}/wp/v2`
 async function getPosts() {
   return axios.get(`${API_URL}/posts`).then(res => {
     const { data } = res
-    return data.map(post => ({
-      ...post,
-      content: post.content.rendered,
-      title: post.title.rendered,
-    }))
+    return data.map(parsePost)
   })
 }
 
-export default { getPosts }
+async function getPostById(id) {
+  return axios
+    .get(`${API_URL}/posts/?filter[p]=${id}`)
+    .then(res => res.data[0])
+    .then(parsePost)
+}
+
+export default { getPosts, getPostById }
+
+const parsePost = post => ({
+  ...post,
+  content: post.content.rendered,
+  title: post.title.rendered,
+})

--- a/templates/vue/src/services/WordpressApi.js
+++ b/templates/vue/src/services/WordpressApi.js
@@ -1,0 +1,16 @@
+import axios from "axios"
+
+const API_URL = `${wpData.rest_url}/wp/v2`
+
+async function getPosts() {
+    return axios.get(`${API_URL}/posts`).then(res => {
+        const { data } = res
+        return data.map(post => ({
+            ...post,
+            content: post.content.rendered,
+            title: post.title.rendered,
+        }))
+    })
+}
+
+export default { getPosts }

--- a/templates/vue/src/services/WordpressApi.js
+++ b/templates/vue/src/services/WordpressApi.js
@@ -3,14 +3,14 @@ import axios from "axios"
 const API_URL = `${wpData.rest_url}/wp/v2`
 
 async function getPosts() {
-    return axios.get(`${API_URL}/posts`).then(res => {
-        const { data } = res
-        return data.map(post => ({
-            ...post,
-            content: post.content.rendered,
-            title: post.title.rendered,
-        }))
-    })
+  return axios.get(`${API_URL}/posts`).then(res => {
+    const { data } = res
+    return data.map(post => ({
+      ...post,
+      content: post.content.rendered,
+      title: post.title.rendered,
+    }))
+  })
 }
 
 export default { getPosts }


### PR DESCRIPTION
Fixes #287

So far both the authoring and the front end works, but I'm not sure if I should move forward with this approach.

- To my knowledge there really isn't a way to "embed" a wordpress post (and only the post) into something like an iframe. In the backend wordpress saves the post content's html in its database which is what I've used here. But this approach means that there is no styling applied to the post content.