### PR TITLE
#306 Gravity Forms Image UI Styling

### DIFF
--- a/templates/libs/gf-image-ui.css
+++ b/templates/libs/gf-image-ui.css
@@ -1,0 +1,155 @@
+.gform_wrapper {
+    width: 50%;
+}
+
+.gfield_checkbox {
+    display: flex;
+    justify-content: space-evenly;
+    align-items: center;
+}
+
+.image-choices-field {
+    max-width: 100%;
+    width: 100%;
+}
+.image-choices-field,
+.gform_wrapper .gfield.image-choices-field {
+	margin-right: -3%;
+}
+.image-choices-field .image-choices-choice,
+.gform_wrapper .gfield.image-choices-field li.image-choices-choice {
+	position: relative;
+	vertical-align: middle;
+	transition: all 0.3s;
+	border-radius: 50%;
+	margin-right: 3% !important;
+	overflow: visible;
+}
+.image-choices-field .image-choices-choice:before {
+	content: "" !important;
+	width: 100%;
+	height: 100%;
+	top: 0;
+	left: 0;
+	margin: 0;
+	z-index: 1;
+	display: block;
+	position: absolute;
+	border-radius: 50%;
+	pointer-events: none;
+	transition: all 0.3s;
+}
+.image-choices-field .image-choices-choice:after {
+	content: "\2714" !important;
+	width: 30px;
+	height: 30px;
+	overflow: hidden;
+	border-radius: 50%;
+	pointer-events: none;
+	transition: all .3s;
+	text-align: center;
+	line-height: 33px;
+	display: block;
+	position: absolute;
+	left: 50%;
+	margin: -15px 0 0 -15px;
+	top: 0;
+	color: #00a7f7;
+	z-index: 2;
+	opacity: 0;
+	background-color: #fff;
+}
+.image-choices-field .image-choices-choice,
+.image-choices-field .image-choices-choice.image-choices-choice-hover
+.image-choices-field .image-choices-choice.image-choices-choice-selected {
+	box-shadow: none;
+	background-color: transparent !important;
+	border-color: transparent !important;
+}
+.image-choices-field .gfield_label {
+	font-size: 1.6em;
+	margin-bottom: 1.6em;
+	display: block;
+	text-align: center;
+}
+.image-choices-field .image-choices-choice label,
+.gform_wrapper .gfield.image-choices-field li.image-choices-choice label {
+	padding: 0 !important;
+	display: block;
+	border: none !important;
+}
+.image-choices-field .image-choices-choice-image-wrap {
+	width: 100%;
+	height: auto;
+	padding-bottom: 100%;
+	background-color: transparent;
+	border-radius: 50%;
+	background-size: cover;
+	box-shadow: 0 0 0 0 rgba(255,255,255,1), 0 0 10px 5px rgba(0,0,0,0);
+	transition: all 0.3s;
+}
+.image-choices-field.image-choices-show-labels .image-choices-choice-text {
+	font-size: inherit;
+	position: absolute;
+	left: 50%;
+	transform: translateX(-50%);
+	bottom: -70px;
+	z-index: 3;
+	transition: all 0.3s;
+	background-color: transparent;
+	border-radius: 15px;
+	padding: 3px 10px 4px;
+	width: 70%;
+}
+
+.image-choices-field .image-choices-choice.image-choices-choice-selected {
+	box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.2);
+}
+.image-choices-field .image-choices-choice.image-choices-choice-selected:before {
+	background-color: rgba(255,255,255, 0.4);
+}
+.image-choices-field .image-choices-choice.image-choices-choice-selected:after {
+	opacity: 1;
+	color: #00a7f7;
+	top: 50%;
+}
+.image-choices-field .image-choices-choice.image-choices-choice-other.image-choices-choice-selected:after {
+	top: 30%;
+}
+.image-choices-field .image-choices-choice.image-choices-choice-selected .image-choices-choice-image-wrap {
+	box-shadow: 0 0 0 4px rgba(255,255,255,1), 0 0 40px 8px rgba(0,0,0,.25);
+}
+.image-choices-field .image-choices-choice.image-choices-choice-selected .image-choices-choice-text {
+	color: #00a7f7;
+}
+.image-choices-field .image-choices-choice.image-choices-choice-focus .image-choices-choice-image-wrap {
+    border-color: #00a7f7;
+}
+.image-choices-field .gfield_radio .image-choices-choice.image-choices-choice-focus.image-choices-choice-selected .image-choices-choice-image-wrap {
+    border-color: #fff;
+}
+
+@media only screen and (max-width: 736px) {
+
+	.image-choices-field .image-choices-choice, 
+	.gform_wrapper .gfield.image-choices-field li.image-choices-choice {
+		width: 48%;
+		margin-right: 2% !important;
+	}
+
+}
+
+@media only screen and (max-width: 480px) {
+
+	.image-choices-field .image-choices-choice, 
+	.gform_wrapper .gfield.image-choices-field li.image-choices-choice {
+		width: 98%;
+		margin-right: 2% !important;
+	}
+
+}
+
+.gfield_checkbox > li > input {
+    position: absolute;
+    z-index: -2;
+}

--- a/templates/libs/gf-image-ui.css
+++ b/templates/libs/gf-image-ui.css
@@ -1,7 +1,3 @@
-.gform_wrapper {
-    width: 50%;
-}
-
 .gfield_checkbox {
     display: flex;
     justify-content: space-evenly;
@@ -19,27 +15,29 @@
 .image-choices-field .image-choices-choice,
 .gform_wrapper .gfield.image-choices-field li.image-choices-choice {
 	position: relative;
-	vertical-align: middle;
 	transition: all 0.3s;
 	border-radius: 50%;
-	margin-right: 3% !important;
 	overflow: visible;
 }
-.image-choices-field .image-choices-choice:before {
-	content: "" !important;
-	width: 100%;
-	height: 100%;
-	top: 0;
-	left: 0;
-	margin: 0;
-	z-index: 1;
-	display: block;
-	position: absolute;
-	border-radius: 50%;
-	pointer-events: none;
-	transition: all 0.3s;
+
+.image-choices-choice-image-wrap {
+	position: relative;
 }
-.image-choices-field .image-choices-choice:after {
+
+.image-choices-choice-selected .image-choices-choice-image-wrap:before {
+	content: "";
+	background: white;
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	border-radius: 50%;
+	z-index: 10;
+	opacity: 0.3;
+}
+
+.image-choices-field .image-choices-choice .image-choices-choice-image-wrap:after {
 	content: "\2714" !important;
 	width: 30px;
 	height: 30px;
@@ -90,25 +88,19 @@
 }
 .image-choices-field.image-choices-show-labels .image-choices-choice-text {
 	font-size: inherit;
-	position: absolute;
-	left: 50%;
-	transform: translateX(-50%);
-	bottom: -70px;
 	z-index: 3;
 	transition: all 0.3s;
 	background-color: transparent;
 	border-radius: 15px;
-	padding: 3px 10px 4px;
-	width: 70%;
 }
 
-.image-choices-field .image-choices-choice.image-choices-choice-selected {
+.image-choices-field .image-choices-choice.image-choices-choice-selected .image-choices-choice-image-wrap {
 	box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.2);
 }
 .image-choices-field .image-choices-choice.image-choices-choice-selected:before {
 	background-color: rgba(255,255,255, 0.4);
 }
-.image-choices-field .image-choices-choice.image-choices-choice-selected:after {
+.image-choices-field .image-choices-choice.image-choices-choice-selected .image-choices-choice-image-wrap:after {
 	opacity: 1;
 	color: #00a7f7;
 	top: 50%;

--- a/templates/single-tapestry.php
+++ b/templates/single-tapestry.php
@@ -102,13 +102,25 @@ get_header(); ?>
         <link crossorigin="anonymous" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" rel="stylesheet" />
         <link href="<?php echo plugin_dir_url(__FILE__) ?>tapestry.css" rel="stylesheet" />
         <link href="<?php echo plugin_dir_url(__FILE__) ?>libs/jquery-ui.min.css" rel="stylesheet" />
+            
+        <!-- Get Gravity Forms CSS if plugin is installed -->
+        <?php if (class_exists("GFCommon")) :
+            echo '<link href="' . GFCommon::get_base_url() . '/css/formsmain.min.css" rel="stylesheet" />';
+        endif; ?>
+
+        <?php if (class_exists("GFImageChoices")) :
+            $GF_Image_Choices_Object = new GFImageChoices();
+            echo '<link href="' . plugin_dir_url(__FILE__) . 'libs/gf-image-ui.css" rel="stylesheet" />';
+            echo '<link href="' . $GF_Image_Choices_Object->get_base_url() . '/css/gf_image_choices.css" rel="stylesheet" />';
+            echo '<script src="' . $GF_Image_Choices_Object->get_base_url() . '/js/gf_image_choices.js" type="application/javascript"></script>';
+        endif; ?>
 
         <script src="<?php echo plugin_dir_url(__FILE__) ?>libs/jquery.min.js" type="application/javascript"></script>
         <script src="<?php echo plugin_dir_url(__FILE__) ?>libs/jquery-ui.min.js" type="application/javascript"></script>
         <script src="<?php echo plugin_dir_url(__FILE__) ?>libs/jscookie.js" type="application/javascript"></script>
         <script src="<?php echo plugin_dir_url(__FILE__) ?>libs/d3.v5.min.js" type="application/javascript"></script>
         <script src="<?php echo plugin_dir_url(__FILE__) ?>libs/h5p-resizer.min.js" charset="UTF-8"></script>
-
+        
         <script>
             // EXAMPLE OF USAGE:
             // thisTapestryTool.setDataset({'abc':'123'});

--- a/templates/vue/src/components/lightbox/GravityForm.vue
+++ b/templates/vue/src/components/lightbox/GravityForm.vue
@@ -124,8 +124,6 @@ export default {
       const allImages = imageContainer.childNodes
       const allImagesArray = Array.from(allImages)
       allImagesArray.forEach(image => {
-        console.log("adding onclick")
-        console.log(image.childNodes[1].parentElement)
         image.childNodes[1].addEventListener("click", function() {
           this.parentElement.classList.toggle("image-choices-choice-selected")
         })

--- a/templates/vue/src/components/lightbox/GravityForm.vue
+++ b/templates/vue/src/components/lightbox/GravityForm.vue
@@ -51,7 +51,6 @@ export default {
     this.loading = false
 
     this.disableAutocomplete()
-    // this.injectImageScripts()
     this.styleImageUI()
 
     if (this.entry) {

--- a/templates/vue/src/components/lightbox/GravityForm.vue
+++ b/templates/vue/src/components/lightbox/GravityForm.vue
@@ -51,6 +51,8 @@ export default {
     this.loading = false
 
     this.disableAutocomplete()
+    // this.injectImageScripts()
+    this.styleImageUI()
 
     if (this.entry) {
       this.populateForm()
@@ -115,6 +117,31 @@ export default {
       formInputs.forEach(input => {
         // Manually sets autocomplete flag for each element of form
         input.autocomplete = "off"
+      })
+    },
+    styleImageUI() {
+      const imageContainer = document.querySelector(".gfield_checkbox")
+      const allImages = imageContainer.childNodes
+      const allImagesArray = Array.from(allImages)
+      allImagesArray.forEach(image => {
+        console.log("adding onclick")
+        console.log(image.childNodes[1].parentElement)
+        image.childNodes[1].addEventListener("click", function() {
+          this.parentElement.classList.toggle("image-choices-choice-selected")
+        })
+        image.childNodes[1].addEventListener("focus", function() {
+          this.parentElement.classList.add("image-choices-choice-focus")
+        })
+        image.childNodes[1].addEventListener("blur", function() {
+          this.parentElement.classList.remove("image-choices-choice-focus")
+        })
+        image.addEventListener("mouseover", function() {
+          this.classList.add("image-choices-choice-hover")
+        })
+        image.addEventListener("mouseout", function() {
+          this.classList.remove("image-choices-choice-hover")
+        })
+        image.classList.add("image-choices-choice")
       })
     },
   },


### PR DESCRIPTION
Added:
- gf-image-ui.css
Stylesheet for forms targeting whole Gravity Forms html box, placing it in GravityForm.vue was not high enough on the scope
- InjectImageStyling() method to GravityForms.vue:
Iterates through the relevant HTML elements and adds event listeners for triggering class changes, activating CSS animation
- Load GravityForms JS and GravityForm Image Choice JS from singleTapestry.php
Loading the plugins CSS and JS keeps our in modal quizzes consistent with Gravity Forms posts