### PR TITLE
Fix H5P console errors

### DIFF
--- a/templates/vue/src/components/TapestryMedia.vue
+++ b/templates/vue/src/components/TapestryMedia.vue
@@ -29,8 +29,7 @@
       v-if="node.mediaFormat === 'h5p'"
       :node="node"
       :width="dimensions.width"
-      :height="dimensions.height"
-      :settings="h5pSettings"
+      :allow-end-screen="allowEndScreen"
       @load="handleLoad"
       @update-settings="updateH5pSettings"
       @timeupdate="updateProgress"
@@ -115,10 +114,6 @@ export default {
 
       if (secondsDiff > SAVE_INTERVAL) {
         await this.updateNodeProgress({ id: this.nodeId, progress: amountViewed })
-
-        if (type === "h5p") {
-          await this.updateH5pSettings(this.h5pSettings)
-        }
 
         this.timeSinceLastSaved = now
       }

--- a/templates/vue/src/components/lightbox/H5PMedia.vue
+++ b/templates/vue/src/components/lightbox/H5PMedia.vue
@@ -12,7 +12,7 @@
       :node="node"
       :width="width"
       :height="height"
-      :settings="settings"
+      @complete="$emit('complete')"
       @is-loaded="handleLoad"
       @show-end-screen="showEndScreen = true"
     />
@@ -38,7 +38,8 @@ export default {
     },
     settings: {
       type: Object,
-      required: true,
+      required: false,
+      default: () => {},
     },
     width: {
       type: Number,
@@ -46,7 +47,8 @@ export default {
     },
     height: {
       type: Number,
-      required: true,
+      required: false,
+      default: undefined,
     },
   },
   data() {


### PR DESCRIPTION
The settings returned from the backend appears to always be an empty string. I removed passing the `settings` prop to the various H5P components which silences the console errors.

This is a temporary fix however, the real issue seems to be coming from the fact that the settings object doesn't exist in the first place.