### PR TITLE
Fixed text node formatting by removing the HTML parser and changing CSS

### DIFF
--- a/templates/vue/src/components/lightbox/TextMedia.vue
+++ b/templates/vue/src/components/lightbox/TextMedia.vue
@@ -1,7 +1,7 @@
 <template>
   <article class="article">
     <h1>{{ node.title }}</h1>
-    <div v-html="html"></div>
+    <div v-html="content"></div>
   </article>
 </template>
 
@@ -15,14 +15,8 @@ export default {
     },
   },
   computed: {
-    html() {
-      const content = this.node.typeData.textContent
-      let htmlText = ""
-      const paragraphs = content.split("\n\n")
-      paragraphs.forEach(text => {
-        htmlText += `<p class="lightbox-text">${text.replace("\n", "<br>")}</p>`
-      })
-      return htmlText
+    content() {
+      return this.node.typeData.textContent
     },
   },
   mounted() {
@@ -50,6 +44,7 @@ export default {
     color: #47425d;
     font-family: "Source Sans Pro", sans-serif;
     font-size: 16px;
+    white-space: pre;
   }
 }
 </style>


### PR DESCRIPTION
Removed:
- HTML parser from Text media Vue component

Added:
- CSS preserving white space 