### PR TITLE
Add node permissions based on role

### DIFF
--- a/templates/single-tapestry.php
+++ b/templates/single-tapestry.php
@@ -10,6 +10,7 @@
  */
 function addNonceToScript()
 {
+    global $wp_roles;
     $params = array(
         'nonce'  => wp_create_nonce('wp_rest'),
         'wpCanEditTapestry' => current_user_can('edit_post', get_the_ID()),
@@ -24,6 +25,7 @@ function addNonceToScript()
         true
     );
     wp_localize_script('wp_tapestry_script', 'wpApiSettings', $params);
+    wp_localize_script('wp_tapestry_script', 'wp', array('roles' => $wp_roles->get_names()));
     wp_enqueue_script('wp_tapestry_script');
 
     wp_add_inline_script( 'wp_tapestry_script', "
@@ -54,6 +56,7 @@ function enqueue_vue_app_build()
 
     // make custom data available to the Vue app with wp_localize_script.
     global $post;
+    global $wp_roles;
     wp_localize_script(
         'tapestry_d3_vue', // vue script handle defined in wp_register_script.
         'wpData', // javascript object that will made availabe to Vue.
@@ -73,7 +76,8 @@ function enqueue_vue_app_build()
             'wpUserId' => apply_filters('determine_current_user', false),
             'adminAjaxUrl' => admin_url('admin-ajax.php'),
             'file_upload_nonce' => wp_create_nonce('media-form'),
-            'upload_url' => admin_url('async-upload.php')
+            'upload_url' => admin_url('async-upload.php'),
+            'roles' => $wp_roles->get_names()
         )
     );
 

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -198,8 +198,11 @@ function tapestryTool(config){
     this.canCurrentUserEdit = () => Boolean(config.wpCanEditTapestry.length)
 
     this.init = function(isReload = false) {
+        const { roles: allRoles } = wp;
+        const roles = Object.keys(allRoles).filter(key => key !== "administrator" && key !== "author");
+
         var reorderPermissions = permissions => {
-            var withoutDuplicates = new Set(["public", "authenticated", ...Object.keys(permissions)])
+            var withoutDuplicates = new Set(["public", "authenticated", ...roles, ...Object.keys(permissions)])
             return [...withoutDuplicates];
         }
 

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -206,11 +206,19 @@ function tapestryTool(config){
             return [...withoutDuplicates];
         }
 
+        const getDefaultRoles = () => {
+            const obj = {}
+            Object.keys(allRoles)
+                .filter(role => role !== "administrator" && role !== "author")
+                .forEach(role => (obj[role] = ["read"]));
+            return obj;
+        }
+
         this.dataset.nodes = this.dataset.nodes.map(node => {
             var updatedNode = fillEmptyFields(node, { accordionProgress: [], skippable: true, behaviour: "embed", completed: false, quiz: [] })
             updatedNode.permissions = fillEmptyFields(
                 updatedNode.permissions, 
-                { authenticated: ["read"] }
+                { authenticated: ["read"], ...getDefaultRoles() }
             );
             updatedNode.permissionsOrder = reorderPermissions(updatedNode.permissions);
 

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -198,8 +198,10 @@ function tapestryTool(config){
     this.canCurrentUserEdit = () => Boolean(config.wpCanEditTapestry.length)
 
     this.init = function(isReload = false) {
+        const exceptions = ["administrator", "author", "editor"];
+
         const { roles: allRoles } = wp;
-        const roles = Object.keys(allRoles).filter(key => key !== "administrator" && key !== "author");
+        const roles = Object.keys(allRoles).filter(key => !exceptions.includes(key));
 
         var reorderPermissions = permissions => {
             var withoutDuplicates = new Set(["public", "authenticated", ...roles, ...Object.keys(permissions)])
@@ -209,7 +211,7 @@ function tapestryTool(config){
         const getDefaultRoles = () => {
             const obj = {}
             Object.keys(allRoles)
-                .filter(role => role !== "administrator" && role !== "author")
+                .filter(key => !exceptions.includes(key))
                 .forEach(role => (obj[role] = ["read"]));
             return obj;
         }

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -532,7 +532,7 @@ export default {
       // keep going up until we find a non-user higher row
       const rowIndex = this.getPermissionRowIndex(rowName)
       const higherRow = this.permissionsOrder[rowIndex - 1]
-      if (higherRow.startsWith("user")) {
+      if (higherRow.startsWith("user") || wpData.roles.hasOwnProperty(rowName)) {
         return this.isPermissionDisabled(higherRow, type)
       }
 
@@ -558,7 +558,7 @@ export default {
       this.$set(this.node.permissions, rowName, newPermissions)
     },
     updatePermissions(value, rowName, type) {
-      if (rowName.startsWith("user")) {
+      if (rowName.startsWith("user") || wpData.roles.hasOwnProperty(rowName)) {
         return this.changeIndividualPermission(value, rowName, type)
       }
       const rowIndex = this.getPermissionRowIndex(rowName)

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -532,7 +532,7 @@ export default {
       // keep going up until we find a non-user higher row
       const rowIndex = this.getPermissionRowIndex(rowName)
       const higherRow = this.permissionsOrder[rowIndex - 1]
-      if (higherRow.startsWith("user") || wpData.roles.hasOwnProperty(rowName)) {
+      if (higherRow.startsWith("user") || wpData.roles.hasOwnProperty(higherRow)) {
         return this.isPermissionDisabled(higherRow, type)
       }
 

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -106,7 +106,13 @@ export default {
         case "edit-node":
           return this.selectedNode.permissionsOrder
         default:
-          return ["public", "authenticated"]
+          return [
+            "public",
+            "authenticated",
+            ...Object.keys(wpData.roles).filter(
+              role => role !== "administrator" && role !== "author"
+            ),
+          ]
       }
     },
     wpCanEditTapestry: function() {

--- a/utilities/class.tapestry-helpers.php
+++ b/utilities/class.tapestry-helpers.php
@@ -176,6 +176,16 @@ class TapestryHelpers
                 in_array($options[$action], $nodePermissions->authenticated)
             ) {
                 return true;
+            } else if (is_user_logged_in()) {
+                $roles = wp_get_current_user()->roles;
+                foreach ($roles as $role) {
+                    if (
+                        property_exists($nodePermissions, $role) && 
+                        in_array($options[$action], $nodePermissions->$role)
+                    ) {
+                        return true;
+                    }
+                }
             } else {
                 foreach ($groupIds as $groupId) {
                     if (

--- a/utilities/class.tapestry-user-roles.php
+++ b/utilities/class.tapestry-user-roles.php
@@ -5,16 +5,26 @@
 class TapestryUserRoles
 {
     /**
+     * Check if the current user is a particular role
+     * 
+     * @return Boolean
+     */
+    static function isRole($role)
+    {
+        return in_array(
+            $role,
+            wp_get_current_user()->roles
+        );
+    }
+
+    /**
      * Check if the current user is an administrator
      * 
      * @return Boolean
      */
     static function isAdministrator()
     {
-        return in_array(
-            'administrator',
-            wp_get_current_user()->roles
-        );
+        return TapestryUserRoles::isRole('administrator');
     }
 
     /**
@@ -24,10 +34,7 @@ class TapestryUserRoles
      */
     static function isEditor()
     {
-        return in_array(
-            'editor',
-            wp_get_current_user()->roles
-        );
+        return TapestryUserRoles::isRole('editor');
     }
 
     /**
@@ -37,10 +44,7 @@ class TapestryUserRoles
      */
     static function isAuthor()
     {
-        return in_array(
-            'author',
-            wp_get_current_user()->roles
-        );
+        return TapestryUserRoles::isRole('author');
     }
 
     /**
@@ -63,9 +67,6 @@ class TapestryUserRoles
      */
     static function isSubscriber()
     {
-        return in_array(
-            'subscriber',
-            wp_get_current_user()->roles
-        );
+        return TapestryUserRoles::isRole('subscriber');
     }
 }


### PR DESCRIPTION
Closes #391 

- Supply app with role information from Wordpress
- Update authoring tool to show available roles
- Update backend to filter out nodes based on role permissions