### PR TITLE
393 Reorder Content Tab

### DIFF
--- a/classes/class.tapestry-node.php
+++ b/classes/class.tapestry-node.php
@@ -35,6 +35,7 @@ class TapestryNode implements ITapestryNode
     private $fullscreen;
     private $tydeType;
     private $showInBackpack;
+    private $childOrdering;
 
     /**
      * Constructor
@@ -73,6 +74,7 @@ class TapestryNode implements ITapestryNode
         $this->fullscreen = false;
         $this->tydeType = '';
         $this->showInBackpack = true;
+        $this->childOrdering = array();
 
         if (TapestryHelpers::isValidTapestryNode($this->nodeMetaId)) {
             $node = $this->_loadFromDatabase();
@@ -165,6 +167,9 @@ class TapestryNode implements ITapestryNode
         }
         if (isset($node->showInBackpack) && is_bool($node->showInBackpack)) {
             $this->showInBackpack = $node->showInBackpack;
+        }
+        if (isset($node->childOrdering) && is_array($node->childOrdering)) {
+            $this->childOrdering = $node->childOrdering;
         }
     }
 
@@ -286,7 +291,8 @@ class TapestryNode implements ITapestryNode
             'quiz'          => $this->quiz,
             'fullscreen'    => $this->fullscreen,
             'tydeType'      => $this->tydeType,
-            'showInBackpack'=> $this->showInBackpack
+            'showInBackpack'=> $this->showInBackpack,
+            'childOrdering' => $this->childOrdering
         ];
     }
 

--- a/templates/vue/package.json
+++ b/templates/vue/package.json
@@ -20,6 +20,7 @@
     "bootstrap-vue": "^2.0.0-rc.28",
     "vue": "^2.6.10",
     "vue-router": "^3.1.3",
+    "vue-slicksort": "^1.1.3",
     "vuex": "^3.1.1"
   },
   "browserslist": [

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -440,18 +440,20 @@
         >
           <div>
             <slick-list
-              v-model="ordering"
+              :value="node.childOrdering"
               lock-axis="y"
-              :lock-to-container-edges="true"
+              @input="updateOrderingArray"
             >
               <slick-item
                 v-for="(id, index) in ordering"
                 :key="index"
                 class="slick-list-item"
                 :index="index"
+                style="z-index: 9999 !important;"
               >
-                <span class="fa fa-bars"></span>
-                {{ getNode(id).title }}
+                <span class="fas fa-bars fa-xs"></span>
+                <span>{{ getNode(id).title }}</span>
+                <span style="color: grey;">id: {{ id }}</span>
               </slick-item>
             </slick-list>
           </div>
@@ -567,7 +569,6 @@ export default {
   },
   computed: {
     ...mapGetters(["getDirectChildren", "getNode"]),
-    ...mapMutations(["updateOrdering"]),
     videoLabel() {
       const labels = {
         [tydeTypes.STAGE]: "Pre-Stage Video URL",
@@ -699,14 +700,6 @@ export default {
       })
       return ordered
     },
-    ordering: {
-      get() {
-        return this.node.childOrdering
-      },
-      set(ord) {
-        this.node.childOrdering = ord
-      },
-    },
   },
   watch: {
     nodeImageUrl: function() {
@@ -745,6 +738,7 @@ export default {
     })
   },
   methods: {
+    ...mapMutations(["updateOrdering"]),
     setInitialTydeType() {
       // only set node types if adding a new node
       if (this.parent && this.modalType === "add-new-node") {
@@ -909,6 +903,12 @@ export default {
         alert("Enter valid user id")
       }
     },
+    updateOrderingArray(arr) {
+      this.updateOrdering({
+        id: this.node.id,
+        ord: arr,
+      })
+    },
   },
 }
 </script>
@@ -980,14 +980,18 @@ table {
   .slick-list-item {
     display: flex;
     height: 25px;
-    border: lightgray solid 1px;
-    margin: 10px;
+    border: lightgray solid 1.5px;
+    margin: 10px 25px;
     border-radius: 5px;
     padding: 15px;
     align-items: center;
 
     > span {
-      margin-right: 10px;
+      margin-right: 25px;
+    }
+
+    > span:last-of-type {
+      margin-left: auto;
     }
   }
 }

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -434,6 +434,28 @@
             </b-row>
           </div>
         </b-tab>
+        <b-tab
+          v-if="node.tydeType === tydeTypes.MODULE || node.mediaType === 'accordion'"
+          title="Ordering"
+        >
+          <div>
+            <slick-list
+              v-model="ordering"
+              lock-axis="y"
+              :lock-to-container-edges="true"
+            >
+              <slick-item
+                v-for="(id, index) in ordering"
+                :key="index"
+                class="slick-list-item"
+                :index="index"
+              >
+                <span class="fa fa-bars"></span>
+                {{ getNode(id).title }}
+              </slick-item>
+            </slick-list>
+          </div>
+        </b-tab>
       </b-tabs>
     </b-container>
     <template slot="modal-footer">
@@ -467,12 +489,13 @@ import Combobox from "./Combobox"
 import QuizModal from "./node-modal/QuizModal"
 import FileUpload from "./FileUpload"
 import H5PApi from "../services/H5PApi"
-import { mapGetters } from "vuex"
+import { mapGetters, mapMutations } from "vuex"
 import { tydeTypes } from "../utils/constants"
 import TydeTypeInput from "./node-modal/TydeTypeInput"
 import WordpressApi from "../services/WordpressApi"
 import GravityFormsApi from "../services/GravityFormsApi"
 import AccordionForm from "./node-modal/AccordionForm"
+import { SlickList, SlickItem } from "vue-slicksort"
 
 export default {
   name: "node-modal",
@@ -482,6 +505,8 @@ export default {
     QuizModal,
     TydeTypeInput,
     FileUpload,
+    SlickItem,
+    SlickList,
   },
   props: {
     node: {
@@ -542,6 +567,7 @@ export default {
   },
   computed: {
     ...mapGetters(["getDirectChildren", "getNode"]),
+    ...mapMutations(["updateOrdering"]),
     videoLabel() {
       const labels = {
         [tydeTypes.STAGE]: "Pre-Stage Video URL",
@@ -656,6 +682,7 @@ export default {
           name: "spaceshipPartHeight",
           value: this.node.typeData.spaceshipPartHeight,
         },
+        { name: "childOrdering", value: this.node.childOrdering },
       ]
     },
     nodeImageUrl() {
@@ -671,6 +698,14 @@ export default {
         ordered[permission] = this.node.permissions[permission]
       })
       return ordered
+    },
+    ordering: {
+      get() {
+        return this.node.childOrdering
+      },
+      set(ord) {
+        this.node.childOrdering = ord
+      },
     },
   },
   watch: {
@@ -939,6 +974,20 @@ table {
 
     &:last-child {
       margin-bottom: 0;
+    }
+  }
+
+  .slick-list-item {
+    display: flex;
+    height: 25px;
+    border: lightgray solid 1px;
+    margin: 10px;
+    border-radius: 5px;
+    padding: 15px;
+    align-items: center;
+
+    > span {
+      margin-right: 10px;
     }
   }
 }

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -445,7 +445,7 @@
               @input="updateOrderingArray"
             >
               <slick-item
-                v-for="(id, index) in ordering"
+                v-for="(id, index) in node.childOrdering"
                 :key="index"
                 class="slick-list-item"
                 :index="index"

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -467,7 +467,7 @@ export default {
         },
       })
 
-      if (!isEdit) {
+      if (!isEdit && this.getParent(id) !== null) {
         this.getNode(this.getParent(id)).childOrdering.push(id)
       }
 

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -85,7 +85,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(["getParent", "selectedNode", "tapestry"]),
+    ...mapGetters(["getParent", "selectedNode", "tapestry", "getNode"]),
     showRootNodeButton: function() {
       return (
         this.tapestryLoaded &&
@@ -176,6 +176,7 @@ export default {
         description: "",
         quiz: [],
         tydeType: tydeTypes.REGULAR,
+        childOrdering: [],
       }
     },
     addRootNode() {
@@ -230,7 +231,10 @@ export default {
         group: 1,
         typeData: {
           linkMetadata: null,
-          progress: [{ group: "viewed", value: 0 }, { group: "unviewed", value: 1 }],
+          progress: [
+            { group: "viewed", value: 0 },
+            { group: "unviewed", value: 1 },
+          ],
           mediaURL: "",
           mediaWidth: 960, //TODO: This needs to be flexible with H5P
           mediaHeight: 600,
@@ -256,6 +260,7 @@ export default {
           x: 3000,
           y: 3000,
         },
+        childOrdering: [],
       }
 
       if (isEdit) {
@@ -386,6 +391,9 @@ export default {
           case "spaceshipPartHeight":
             newNodeEntry.typeData.spaceshipPartHeight = fieldValue
             break
+          case "childOrdering":
+            newNodeEntry.childOrdering = fieldValue
+            break
           default:
             break
         }
@@ -458,6 +466,10 @@ export default {
           [this.yORfy]: newNodeEntry.coordinates.y,
         },
       })
+
+      if (!isEdit) {
+        this.getNode(this.getParent(id)).childOrdering.push(id)
+      }
 
       thisTapestryTool.setDataset(this.tapestry)
       thisTapestryTool.setOriginalDataset(this.tapestry)

--- a/templates/vue/src/components/lightbox/AccordionMedia.vue
+++ b/templates/vue/src/components/lightbox/AccordionMedia.vue
@@ -138,7 +138,7 @@ export default {
       return this.activeIndex < this.rows.length - 1
     },
     rows() {
-      return this.getDirectChildren(this.node.id).map(this.getNode)
+      return this.node.childOrdering.map(this.getNode)
     },
     dimensions() {
       if (!this.isMounted) {

--- a/templates/vue/src/components/tyde/TydeModule.vue
+++ b/templates/vue/src/components/tyde/TydeModule.vue
@@ -30,7 +30,7 @@ export default {
       return this.getNode(this.nodeId)
     },
     stages() {
-      return this.getDirectChildren(this.nodeId)
+      return this.node.childOrdering
     },
     activeStage() {
       return this.stages[this.activeStageIndex]

--- a/templates/vue/src/store/mutations.js
+++ b/templates/vue/src/store/mutations.js
@@ -1,11 +1,12 @@
 import Helpers from "../utils/Helpers"
+import { tydeTypes } from "../utils/constants"
 
 export function init(state, dataset) {
   setDataset(state, dataset)
   state.selectedNodeId = dataset.rootId
   state.tapestryIsLoaded = true
   state.nodes
-    .filter(n => n.tydeType === "Module" || n.mediaType === "accordion")
+    .filter(n => n.tydeType === tydeTypes.MODULE || n.mediaType === "accordion")
     .forEach(n => initializeOrdering(state, n.id))
 }
 
@@ -130,4 +131,11 @@ export function initializeOrdering(state, id) {
   getChildIds(state, id)
     .filter(cid => !node.childOrdering.includes(cid))
     .forEach(id => node.childOrdering.push(id))
+  const children = getChildIds(state, id)
+  node.childOrdering.filter(id => children.includes(id))
+}
+
+export function updateOrdering(state, payload) {
+  const nodeIndex = Helpers.findNodeIndex(payload.id, state)
+  state.nodes[nodeIndex].childOrdering = payload.ord
 }

--- a/templates/vue/src/store/mutations.js
+++ b/templates/vue/src/store/mutations.js
@@ -4,6 +4,9 @@ export function init(state, dataset) {
   setDataset(state, dataset)
   state.selectedNodeId = dataset.rootId
   state.tapestryIsLoaded = true
+  state.nodes
+    .filter(n => n.tydeType === "Module" || n.mediaType === "accordion")
+    .forEach(n => initializeOrdering(state, n.id))
 }
 
 export function setDataset(state, dataset) {
@@ -120,4 +123,11 @@ function getChildIds(state, nodeId) {
       link.source.id == undefined ? link.source == nodeId : link.source.id == nodeId
     )
     .map(link => (link.target.id == undefined ? link.target : link.target.id))
+}
+
+export function initializeOrdering(state, id) {
+  const node = state.nodes[Helpers.findNodeIndex(id, state)]
+  getChildIds(state, id)
+    .filter(cid => !node.childOrdering.includes(cid))
+    .forEach(id => node.childOrdering.push(id))
 }


### PR DESCRIPTION
Added:
 - `childOrdering` variable to modules and accordions
 - Ordering tab with SlickSort component to Modules and Accordians
 - `updateOrdering` mutation to update variable

Changed:
 - Updated how accordians and modules display their children to be based on variable