### PR TITLE
Allow authors to select and move multiple nodes together

### DIFF
--- a/templates/single-tapestry.php
+++ b/templates/single-tapestry.php
@@ -114,6 +114,7 @@ get_header(); ?>
         <script src="<?php echo plugin_dir_url(__FILE__) ?>libs/jscookie.js" type="application/javascript"></script>
         <script src="<?php echo plugin_dir_url(__FILE__) ?>libs/d3.v5.min.js" type="application/javascript"></script>
         <script src="<?php echo plugin_dir_url(__FILE__) ?>libs/h5p-resizer.min.js" charset="UTF-8"></script>
+        <script src="https://thibaultjanbeyer.github.io/DragSelect/ds.min.js"></script>
 
         <script>
             // EXAMPLE OF USAGE:

--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -218,6 +218,7 @@ body {
 .node {
     cursor: pointer;
     z-index: 0;
+    user-select: none;
 }
 
 .node .meta {

--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -2,7 +2,7 @@
 
 body {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; 
-    font-size: 16px; 
+    font-size: 16px;
     z-index: 0;
 }
 * {

--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -401,6 +401,20 @@ input[type="checkbox"][disabled] {
     padding: 0;
 }
 
+rect.selectable {
+    fill: orange;
+    fill-opacity: 0;
+}
+
 .node-selected circle {
-    fill: #ff571a;
+    fill: orange;
+    fill-opacity: 0.7;
+}
+
+.node-selected path.grandchild, .node-selected .grandchild {
+    fill: orange;
+}
+
+.node-selected rect.selectable {
+    fill-opacity: 0.7;
 }

--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -402,17 +402,17 @@ input[type="checkbox"][disabled] {
 }
 
 rect.selectable {
-    fill: orange;
+    fill: #11a6d8;
     fill-opacity: 0;
 }
 
 .node-selected circle {
-    fill: orange;
+    fill: #11a6d8;
     fill-opacity: 0.7;
 }
 
 .node-selected path.grandchild, .node-selected .grandchild {
-    fill: orange;
+    fill: #11a6d8;
 }
 
 .node-selected rect.selectable {

--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -402,5 +402,5 @@ input[type="checkbox"][disabled] {
 }
 
 .node-selected circle {
-    fill: #ed7565;
+    fill: #ff571a;
 }

--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -399,3 +399,7 @@ input[type="checkbox"][disabled] {
     margin: 0;
     padding: 0;
 }
+
+.node-selected circle {
+    fill: #ed7565;
+}

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -829,7 +829,11 @@ function tapestryTool(config){
     function initializeSelection() {
         new DragSelect({
             selectables: document.querySelectorAll(".node"),
-            onDragStart: () => selection.clear(),
+            onDragStart: () => {
+                if (!isMultiSelect) {
+                    selection.clear()
+                }
+            },
             onElementSelect: node => {
                 const id = node.id.split("node-")[1]
                 selection.add(tapestry.dataset.nodes[findNodeIndex(id)])

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -1362,6 +1362,53 @@ function tapestryTool(config){
                         return PROGRESS_THICKNESS;
                     }
                 });
+
+        nodes.selectAll(".selectable")
+            .attr("class", function (d) {
+                if (!getViewable(d))
+                    return "selectable grandchild";
+                else return "selectable";
+            })
+            .transition()
+            .duration(TRANSITION_DURATION)
+            .attr("rx", function (d) {
+                if (d.hideProgress && d.imageURL.length) {
+                    return 0;
+                }
+                return getRadius(d);
+            })
+            .attr("ry", function (d) {
+                if (d.hideProgress && d.imageURL.length) {
+                    return 0;
+                }
+                return getRadius(d);
+            })
+            .attr("stroke", function (d) {
+                if (!getViewable(d) || d.hideProgress)
+                    return "transparent";
+                else if (d.nodeType === "grandchild") 
+                    return COLOR_GRANDCHILD;
+                else if (!d.accessible)
+                    return COLOR_LINK;
+                else return COLOR_STROKE;
+            })
+            .attr("width", function (d) {
+                return getRadius(d) * 2;
+            })
+            .attr("height", function (d) {
+                return getRadius(d) * 2;
+            })
+            .attr("x", function (d) {
+                return - getRadius(d);
+            })
+            .attr("y", function (d) {
+                return - getRadius(d);
+            })
+            .attr("stroke-width", function (d) {
+                if (!d.hideProgress) {
+                    return PROGRESS_THICKNESS;
+                }
+            });
         
         /* Attach images to be used within each node */
         nodes.selectAll("defs")

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -876,6 +876,22 @@ function tapestryTool(config){
             rebuildNodeContents();
         }
     }
+
+    const selection = new Set();
+    let isMultiSelect = false;
+
+    document.addEventListener("keydown", evt => {
+        if (evt.code === "Escape") {
+            selection.clear();
+        }
+        if (evt.ctrlKey || evt.shiftKey || evt.metaKey) {
+            isMultiSelect = true;
+        }
+    });
+
+    document.addEventListener("keyup", () => {
+        isMultiSelect = false;
+    })
     
     /* Draws the components that make up node */
     function buildNodeContents() {
@@ -1027,7 +1043,11 @@ function tapestryTool(config){
                 recordAnalyticsEvent('user', 'click', 'node', d.id);
                 if (root != d.id) { // prevent multiple clicks
                     if (config.wpCanEditTapestry || d.accessible) {
-                        tapestry.selectNode(d.id)
+                        if (!isMultiSelect) {
+                            tapestry.selectNode(d.id);
+                            selection.clear();
+                        }
+                        selection.add(d);
                     }
                 }
             });
@@ -1835,7 +1855,6 @@ function tapestryTool(config){
                     //Update the dataset with new values
                     tapestry.dataset.nodes[index].typeData.progress[0].value = amountViewed;
                     tapestry.dataset.nodes[index].typeData.progress[1].value = amountUnviewed;
-                    tapestry.dataset.nodes[index].unlocked = unlocked ? true : false;
 
                     var questions = tapestry.dataset.nodes[index].quiz;
                     if (quizCompletionInfo) {

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -855,6 +855,7 @@ function tapestryTool(config){
         if (evt.ctrlKey || evt.shiftKey || evt.metaKey) {
             isMultiSelect = true;
             if (evt.code === "KeyA") {
+                evt.preventDefault();
                 tapestry.dataset.nodes.forEach(d => selection.add(d));
             }
         }

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -1024,10 +1024,14 @@ function tapestryTool(config){
             return;
         }
 
+        const xBeforeDrag = d[xORfx]
+        const yBeforeDrag = d[yORfy]
+        const deltaX = d3.event.x - xBeforeDrag
+        const deltaY = d3.event.y - yBeforeDrag
         selection.forEach(nd => {
             if (canEditNode(nd)) {
-                nd[xORfx] = getBoundedCoord(d3.event.x, tapestryDimensionsBeforeDrag.width+(MAX_RADIUS*2));
-                nd[yORfy] = getBoundedCoord(d3.event.y, tapestryDimensionsBeforeDrag.height+(MAX_RADIUS*2));
+                nd[xORfx] = getBoundedCoord(nd[xORfx] + deltaX, tapestryDimensionsBeforeDrag.width+(MAX_RADIUS*2));
+                nd[yORfy] = getBoundedCoord(nd[yORfy] + deltaY, tapestryDimensionsBeforeDrag.height+(MAX_RADIUS*2));
             } else {
                 nd[xORfx] = getBoundedCoord(nd.x, tapestryDimensionsBeforeDrag.width);
                 nd[yORfy] = getBoundedCoord(nd.y, tapestryDimensionsBeforeDrag.height);

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -967,6 +967,63 @@ function tapestryTool(config){
                     }
                 }
             });
+        
+        
+        nodes.append("rect")
+            .attr("class", function (d) {
+                if (d.nodeType === "grandchild") return "selectable grandchild";
+                return "selectable";
+            })
+            .attr("rx", function (d) {
+                if (d.hideProgress && d.imageURL.length) {
+                    return 0;
+                }
+                return getRadius(d);
+            })
+            .attr("ry", function (d) {
+                if (d.hideProgress && d.imageURL.length) {
+                    return 0;
+                }
+                return getRadius(d);
+            })
+            .attr("data-id", function (d) {
+                return d.id;
+            })
+            .attr("stroke-width", function (d) {
+                if (!d.hideProgress) {
+                    return PROGRESS_THICKNESS;
+                }
+            })
+            .attr("stroke", function (d) {
+                if (!getViewable(d) || d.hideProgress)
+                    return "transparent";
+                else if (d.nodeType === "grandchild")
+                    return COLOR_GRANDCHILD;
+                else if (!d.accessible)
+                    return COLOR_LINK;
+                else return COLOR_STROKE;
+            })
+            .attr("width", function (d) {
+                if (!getViewable(d)) return 0;
+                return getRadius(d) * 2;
+            })
+            .attr("height", function (d) {
+                if (!getViewable(d)) return 0;
+                return getRadius(d) * 2;
+            })
+            .attr("x", function (d) {
+                return - getRadius(d);
+            })
+            .attr("y", function (d) {
+                return - getRadius(d);
+            })
+            .on("click keydown", function (d) {
+                if (root === d.id && d.hideMedia) {
+                    if (config.wpCanEditTapestry || d.accessible) {
+                        goToNode(d.id)
+                    }
+                }
+            });
     
         nodes.append("circle")
             .filter(function (d) {

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -837,6 +837,10 @@ function tapestryTool(config){
             onElementSelect: node => {
                 const id = node.id.split("node-")[1]
                 selection.add(tapestry.dataset.nodes[findNodeIndex(id)])
+            },
+            onElementUnselect: node => {
+                const id = node.id.split("node-")[1]
+                selection.delete(tapestry.dataset.nodes[findNodeIndex(id)])
             }
         });
     }

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -850,6 +850,9 @@ function tapestryTool(config){
         }
         if (evt.ctrlKey || evt.shiftKey || evt.metaKey) {
             isMultiSelect = true;
+            if (evt.code === "KeyA") {
+                tapestry.dataset.nodes.forEach(d => selection.add(d));
+            }
         }
     });
 

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -287,6 +287,8 @@ function tapestryTool(config){
             $("#" + TAPESTRY_CONTAINER_ID + " > svg").prepend(nodeLinkLine);
             recordAnalyticsEvent('app', 'load', 'tapestry', tapestrySlug);
         }
+
+        initializeSelection();
     }
 
     this.resetNodeCache = function() {
@@ -824,6 +826,17 @@ function tapestryTool(config){
         }
     }
 
+    function initializeSelection() {
+        new DragSelect({
+            selectables: document.querySelectorAll(".node"),
+            onDragStart: () => selection.clear(),
+            onElementSelect: node => {
+                const id = node.id.split("node-")[1]
+                selection.add(tapestry.dataset.nodes[findNodeIndex(id)])
+            }
+        });
+    }
+
     const selection = createSelection();
     let isMultiSelect = false;
 
@@ -848,12 +861,10 @@ function tapestryTool(config){
             },
             add(node) {
                 data.add(node);
-                if (data.size > 1) {
-                    data.forEach(d => {
-                        const nd = document.getElementById(`node-${d.id}`);
-                        nd.classList.add("node-selected");
-                    })
-                }
+                data.forEach(d => {
+                    const nd = document.getElementById(`node-${d.id}`);
+                    nd.classList.add("node-selected");
+                })
             },
             has(node) {
                 return data.has(node);


### PR DESCRIPTION
Closes #411

- Add node selection using `cmd`, `ctrl` and `shift` keys
- Add node selection using a selection box using the `DragSelect` library
- Select all nodes using `cmd+A`
- Clear selection by either clicking outside a node or pressing the `esc` key
- Selected nodes are currently highlighted orange, but can be easily changed if need be

**Testing**

- Go to a tapestry that you've previously made
- Select around using the commands above