### PR TITLE
418 Display GF Images In Previous Activity

### DIFF
--- a/classes/class.tapestry-user-progress.php
+++ b/classes/class.tapestry-user-progress.php
@@ -183,7 +183,10 @@ class TapestryUserProgress implements ITapestryUserProgress
                     }
                 ))[0];
                 if($entry[$input['id']] != ''){
-                    $entry[$input['id']] = $correspondingChoice['imageChoices_image'];
+                    $inputMap = new stdClass();
+                    $inputMap->choiceText = $label;
+                    $inputMap->imageUrl = $correspondingChoice['imageChoices_image'];
+                    $entry[$input['id']] = $inputMap;
                 }
             }
         }

--- a/classes/class.tapestry-user-progress.php
+++ b/classes/class.tapestry-user-progress.php
@@ -155,8 +155,40 @@ class TapestryUserProgress implements ITapestryUserProgress
                 $formEntryMap->$formId = $entry;
             }
         }
-
+        
+        foreach ((array)$formEntryMap as $formId => $entry) {
+            $formEntryMap->$formId = $this->_getImageChoices($formId, $entry);
+        }
         return $formEntryMap;
+    }
+    
+    private function _getImageChoices($formId, &$entry)
+    {   
+        $field_types = array('checkbox', 'radio');
+        $form = GFAPI::get_form( $formId );
+        $fields = GFAPI::get_fields_by_type( $form, $field_types );
+        $image_choices_fields = array();
+        foreach($fields as &$field) {
+            if ( is_object( $field ) && property_exists($field, 'imageChoices_enableImages') && !empty($field->imageChoices_enableImages)) {
+                $image_choices_fields[$field->id] = $field;
+            }
+        }
+        foreach($image_choices_fields as $id => $field ) {
+            foreach ($field->inputs as $input) {
+                $label = $input['label'];
+                $correspondingChoice = array_values(array_filter(
+                    $field['choices'],
+                    function ($e) use ($label) {
+                        return $e['value'] == $label;
+                    }
+                ))[0];
+                if($entry[$input['id']] != ''){
+                    $entry[$input['id']] = $correspondingChoice['imageChoices_image'];
+                }
+            }
+        }
+        
+        return $entry;
     }
 
     private function _updateUserProgress($progressValue)

--- a/templates/vue/src/components/TapestryActivity.vue
+++ b/templates/vue/src/components/TapestryActivity.vue
@@ -3,7 +3,7 @@
     <div class="icon"><tapestry-icon :icon="type" /></div>
     <div v-if="type === 'text'" class="text">{{ entry }}</div>
     <ul v-if="type === 'checklist'" class="checklist">
-      <li v-for="choice in entry" :key="choice">
+      <li v-for="(choice, index) in entry" :key="index">
         <img :src="choice.imageUrl" />
         {{ choice.choiceText }}
       </li>
@@ -41,12 +41,13 @@ export default {
 
 <style lang="scss" scoped>
 .tapestry-activity {
+  position: relative;
   align-items: center;
   background: #262626;
   border-radius: 8px;
   display: flex;
   margin-bottom: 8px;
-  padding: 8px 16px;
+  padding: 8px 16px 8px 38px;
   justify-content: center;
 
   &:last-child {
@@ -54,9 +55,10 @@ export default {
   }
 
   .icon {
-    margin-right: 16px;
     height: 24px;
     width: 24px;
+    position: absolute;
+    left: 8px;
   }
 
   .checklist {
@@ -74,7 +76,6 @@ export default {
       > img {
         width: 100px;
         height: auto;
-        padding: 10px;
       }
     }
   }

--- a/templates/vue/src/components/TapestryActivity.vue
+++ b/templates/vue/src/components/TapestryActivity.vue
@@ -3,7 +3,10 @@
     <div class="icon"><tapestry-icon :icon="type" /></div>
     <div v-if="type === 'text'" class="text">{{ entry }}</div>
     <ul v-if="type === 'checklist'" class="checklist">
-      <li v-for="choice in entry" :key="choice">{{ choice }}</li>
+      <li v-for="choice in entry" :key="choice">
+        <img :src="choice.imageUrl" />
+        {{ choice.choiceText }}
+      </li>
     </ul>
     <audio v-if="type === 'audio'" controls :src="src"></audio>
   </div>
@@ -44,6 +47,7 @@ export default {
   display: flex;
   margin-bottom: 8px;
   padding: 8px 16px;
+  justify-content: center;
 
   &:last-child {
     margin-bottom: 0;
@@ -60,9 +64,17 @@ export default {
     display: flex;
 
     li {
+      display: flex;
+      flex-direction: column;
       margin-right: 8px;
       &:last-child {
         margin-right: 0;
+      }
+
+      > img {
+        width: 100px;
+        height: auto;
+        padding: 10px;
       }
     }
   }

--- a/templates/vue/src/store/getters.js
+++ b/templates/vue/src/store/getters.js
@@ -60,6 +60,6 @@ function formatEntry(answers, answerType) {
     }
   }
   if (answerType === "checklistId") {
-    return { type: "checklist", entry: answers.filter(answer => answer.length) }
+    return { type: "checklist", entry: answers.filter(answer => answer !== "") }
   }
 }


### PR DESCRIPTION
Closes Issue #418 
Added:
- `_getImageChoices` function to `getEntry` endpoint
Modified:
- getters to properly fetch new format of checklist entry
- TapestryActivity to properly display images and text

Steps to test:
1. Make an image checklist activity, and fill it out
2. Make a followup activity of any type, selecting the previous activity to follow up on
3. Verify the image and captions selected render correctly upon launching second activity

Further todos:
- Test with tyde spaceship/module summary 