### PR TITLE
426 add X and Prev buttons to stage

### DIFF
--- a/templates/vue/src/components/tyde/TydeButton.vue
+++ b/templates/vue/src/components/tyde/TydeButton.vue
@@ -4,7 +4,7 @@
     :style="cssProps"
     @click="$emit('click')"
   >
-    <i :class="iconClass"></i>
+    <i v-if="icon.length" :class="iconClass"></i>
     <slot></slot>
   </button>
 </template>
@@ -15,7 +15,8 @@ export default {
   props: {
     icon: {
       type: String,
-      required: true,
+      required: false,
+      default: "",
     },
     label: {
       type: String,
@@ -50,6 +51,8 @@ export default {
   font-size: 30px;
   margin-right: 16px;
   transition: all 0.2s ease;
+  padding: 0em 0.4em;
+  box-shadow: 0 0 20px -8px #000;
 
   &.has-label {
     width: auto;
@@ -81,10 +84,17 @@ export default {
     outline: none;
   }
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: var(--tapestry-light-blue);
     color: white;
     transform: scale(1.1);
+  }
+
+  &:disabled {
+    color: #999;
+    opacity: 0.8;
+    cursor: default;
+    box-shadow: none;
   }
 }
 </style>

--- a/templates/vue/src/components/tyde/TydeModule.vue
+++ b/templates/vue/src/components/tyde/TydeModule.vue
@@ -1,6 +1,12 @@
 <template>
   <div :id="`module-${nodeId}`" class="module-wrapper">
-    <tyde-stage :node-id="activeStage" @next="next"></tyde-stage>
+    <tyde-stage
+      :node-id="activeStage"
+      :stage-index="activeStageIndex"
+      @next="next"
+      @close="$emit('done')"
+      @prev="prev"
+    ></tyde-stage>
   </div>
 </template>
 
@@ -64,6 +70,11 @@ export default {
       } else {
         this.openLightbox(this.nodeId)
         this.$emit("done")
+      }
+    },
+    prev() {
+      if (this.activeStageIndex > 0) {
+        this.activeStageIndex--
       }
     },
   },

--- a/templates/vue/src/components/tyde/TydeStage.vue
+++ b/templates/vue/src/components/tyde/TydeStage.vue
@@ -10,6 +10,9 @@
           </div>
         </div>
         <h1>{{ node.title }}</h1>
+        <button @click="$emit('close')">
+          <i class="fas fa-times fa-2x"></i>
+        </button>
       </div>
       <section>
         <tyde-topic
@@ -22,6 +25,9 @@
         />
       </section>
       <footer>
+        <button :class="stageIndex === 0 ? 'disabled' : ''" @click="$emit('prev')">
+          Prev
+        </button>
         <button v-if="done" @click="$emit('next')">
           Next
         </button>
@@ -49,6 +55,10 @@ export default {
     nodeId: {
       type: [String, Number],
       required: true,
+    },
+    stageIndex: {
+      type: [Number],
+      default: 1,
     },
   },
   computed: {
@@ -130,6 +140,16 @@ body.tapestry-stage-open {
     font-family: "VT323", monospace;
     color: var(--tyde-border-green);
     align-items: center;
+
+    > button {
+      border: none;
+      font-family: inherit;
+      font-size: 100%;
+      background: none;
+      color: inherit;
+      margin-left: auto;
+      margin-right: 75px;
+    }
 
     .stage-star {
       margin-left: 32vw;
@@ -222,7 +242,7 @@ body.tapestry-stage-open {
 
     button {
       background: none;
-      margin: 0;
+      margin: 0 0 0 30px;
       padding: 0;
 
       font-family: inherit;
@@ -231,6 +251,14 @@ body.tapestry-stage-open {
 
       &:hover {
         text-decoration: underline;
+      }
+    }
+
+    button.disabled {
+      opacity: 80%;
+      cursor: auto;
+      &:hover {
+        text-decoration: none;
       }
     }
   }

--- a/templates/vue/src/components/tyde/TydeStage.vue
+++ b/templates/vue/src/components/tyde/TydeStage.vue
@@ -10,9 +10,11 @@
           </div>
         </div>
         <h1>{{ node.title }}</h1>
-        <button @click="$emit('close')">
-          <i class="fas fa-times fa-2x"></i>
-        </button>
+        <tyde-button
+          class="close-button"
+          icon="times"
+          @click="$emit('close')"
+        ></tyde-button>
       </div>
       <section>
         <tyde-topic
@@ -25,12 +27,16 @@
         />
       </section>
       <footer>
-        <button :class="stageIndex === 0 ? 'disabled' : ''" @click="$emit('prev')">
-          Prev
-        </button>
-        <button v-if="done" @click="$emit('next')">
-          Next
-        </button>
+        <tyde-button
+          :disabled="!stageIndex"
+          label="Prev"
+          @click="$emit(stageIndex ? 'prev' : '')"
+        ></tyde-button>
+        <tyde-button
+          :disabled="!done"
+          label="Next"
+          @click="$emit(done ? 'next' : '')"
+        ></tyde-button>
       </footer>
     </div>
   </div>
@@ -38,6 +44,7 @@
 
 <script>
 import { mapGetters } from "vuex"
+import TydeButton from "./TydeButton"
 import TydeTopic from "./TydeTopic"
 import TydeProgressBar from "./TydeProgressBar"
 import ActiveStar from "@/assets/star-active.png"
@@ -48,6 +55,7 @@ import { tydeTypes } from "@/utils/constants"
 export default {
   name: "tyde-stage",
   components: {
+    TydeButton,
     TydeTopic,
     TydeProgressBar,
   },
@@ -141,16 +149,6 @@ body.tapestry-stage-open {
     color: var(--tyde-border-green);
     align-items: center;
 
-    > button {
-      border: none;
-      font-family: inherit;
-      font-size: 100%;
-      background: none;
-      color: inherit;
-      margin-left: auto;
-      margin-right: 75px;
-    }
-
     .stage-star {
       margin-left: 32vw;
       margin-right: 30px;
@@ -178,6 +176,13 @@ body.tapestry-stage-open {
       &::before {
         display: none;
       }
+    }
+
+    .close-button {
+      position: absolute;
+      top: -25px;
+      right: -25px;
+      z-index: 20;
     }
   }
 
@@ -236,31 +241,10 @@ body.tapestry-stage-open {
   }
 
   footer {
-    margin-left: 30vw;
+    margin-right: 11vw;
     display: flex;
     justify-content: flex-end;
-
-    button {
-      background: none;
-      margin: 0 0 0 30px;
-      padding: 0;
-
-      font-family: inherit;
-      font-size: 2.5em;
-      color: inherit;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-
-    button.disabled {
-      opacity: 80%;
-      cursor: auto;
-      &:hover {
-        text-decoration: none;
-      }
-    }
+    margin-top: 80px;
   }
 }
 </style>


### PR DESCRIPTION
Closes #426 
Added:
- Buttons, functionality and styling

Steps to Test:
1. Make a module with more than one stage child
2. Remove progress bar, title, and give module a thumbnail.
3. Press on module to launch
4. Click X to close and verify action is complete
5. Relaunch module, click Next once first stage is complete
6. Click "Prev" and verify you have returned to previous stage