### PR TITLE
Add blank options to combobox

### DIFF
--- a/templates/vue/src/components/node-modal/QuizModal.vue
+++ b/templates/vue/src/components/node-modal/QuizModal.vue
@@ -230,10 +230,12 @@ export default {
     },
   },
   async mounted() {
-    const forms = await GravityFormsApi.getAllForms()
-    const h5ps = await H5PApi.getAllContent()
+    var forms = await GravityFormsApi.getAllForms()
+    var h5ps = await H5PApi.getAllContent()
     this.formOptions = forms
+    this.formOptions.push({id: "", title: "None"})
     this.h5pOptions = h5ps
+    this.h5pOptions.push({id: "", title: "None"})
   },
   methods: {
     addQuestion() {


### PR DESCRIPTION
Closes #438 
Adds:
- Blank options to quiz form for field submission

To Test:
- Create an Activity node and assign one of the "answer" options to a GF form 
- Submit and reopen the edit page, remove the quiz as an option by setting field to "None"