### PR TITLE
Show special icon for activity as well in accordion row

### DIFF
--- a/templates/vue/src/components/lightbox/AccordionMedia.vue
+++ b/templates/vue/src/components/lightbox/AccordionMedia.vue
@@ -396,6 +396,7 @@ button[disabled] {
 
   &-activity {
     width: 52px;
+    margin-right: 10px;
   }
 }
 

--- a/templates/vue/src/components/lightbox/AccordionMedia.vue
+++ b/templates/vue/src/components/lightbox/AccordionMedia.vue
@@ -30,7 +30,7 @@
             </button>
             <div class="icon-container">
               <tyde-icon
-                v-if="row.node.mediaType === 'gravity-form'"
+                v-if="showActivityIcon(row.node.mediaType)"
                 class="icon icon-activity"
                 icon="activity"
               ></tyde-icon>
@@ -266,6 +266,9 @@ export default {
       }
       this.updateUserFavourites(updatedFavouritesList)
     },
+    showActivityIcon(mediaType) {
+      return mediaType === "gravity-form" || mediaType === "activity"
+    },
   },
 }
 </script>
@@ -344,8 +347,8 @@ button[disabled] {
 
 .button-row {
   display: flex;
-  
-  &-trigger{
+
+  &-trigger {
     display: flex;
     align-items: center;
     background: none;


### PR DESCRIPTION
#458 

Testing:
Create an accordion node - node1
Create a child accordion node, child text node and child activity node from node 1
When you view accordion node1, check that special icon appears for both rows representing the accordion and activity but not the text node