### PR TITLE
If a parent node has a certain permission, its children should be limited to that permission too

### DIFF
--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -387,31 +387,37 @@ class Tapestry implements ITapestry
 
     private function _filterNodeMetaIdsByPermissions($nodeMetaIds, $rootId)
     {
-        $newNodeMetaIds = [];
         $options = TapestryNodePermissions::getNodePermissions();
         $userId = wp_get_current_user()->ID;
         $groupIds = TapestryHelpers::getGroupIdsOfUser($userId, $this->postId);
 
+        $nodesPermitted = [];
         foreach ($nodeMetaIds as $nodeMetaId) {
-            if ($this->_checkPathIsAllowed($nodeMetaId, $rootId)) {
-                array_push($newNodeMetaIds, $nodeMetaId);
+            if ($this->_pathIsAllowed($nodeMetaId, $rootId)) {
+                array_push($nodesPermitted, $nodeMetaId);
             }
         }
-
-        return $newNodeMetaIds;
+        return $nodesPermitted;
     }
 
-    private function _checkPathIsAllowed($nodeMetaId, $rootId)
+    private function _pathIsAllowed($from, $to, $checked = [])
     {
-        if (TapestryHelpers::currentUserIsAllowed('READ', $nodeMetaId, $this->postId))
+        if (in_array($from, $checked)) {
+            return false;
+        }
+
+        if (TapestryHelpers::currentUserIsAllowed('READ', $from, $this->postId))
         {
-            if ($nodeMetaId == $rootId) {
+            if ($from == $to) {
                 return true;
             }
 
+            $checked[] = $from;
+
             foreach ($this->links as $link) {
-                if ($link->target == $nodeMetaId) {
-                    return $this->_checkPathIsAllowed($link->source, $rootId);
+                if (($link->target == $from && $this->_pathIsAllowed($link->source, $to, $checked)) || 
+                    ($link->source == $from && $this->_pathIsAllowed($link->target, $to, $checked))) {
+                    return true;
                 }
             }   
         }

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -1858,6 +1858,9 @@ function tapestryTool(config){
     function getParent(node) {
         const links = tapestry.dataset.links;
         const link = links.find(l => l.target == node.id || l.target.id == node.id);
+        if (!link) {
+            return null
+        }
         return typeof link.source === "object" 
             ? link.source 
             : getNodeById(link.source);

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -122,7 +122,7 @@ export default {
   },
   async created() {
     const tapestryApi = new TapestryApi(wpPostId)
-    return await tapestryApi.getUserFavourites()
+    this.favourites = await tapestryApi.getUserFavourites()
   },
   mounted() {
     window.addEventListener("change-selected-node", this.changeSelectedNode)


### PR DESCRIPTION
Fixed issue with children nodes of parent nodes without permission to appear on-screen appearing
#462 

Testing:
Create node1 and multiple child nodes
Edit node 1 and in access tab change, uncheck read

In incognito mode (or log out of your account), check that the child nodes don't appear when refreshed