### PR TITLE
Fix Gravity Form Image Checklist Styling Bug

### DIFF
--- a/templates/vue/src/components/lightbox/GravityForm.vue
+++ b/templates/vue/src/components/lightbox/GravityForm.vue
@@ -141,6 +141,15 @@ export default {
           image.classList.add("image-choices-choice")
         })
       }
+
+      const optionList = document.querySelector(".gfield_checkbox")
+      if(optionList){
+        const allListElements = optionList.childNodes
+        const allLIArray = Array.from(allListElements)
+        allLIArray.forEach(li => {
+          li.style.height = "125px"
+        })
+      }
     },
   },
 }


### PR DESCRIPTION
Adds
 - fixed height styling to GF checklist LI's

Testing steps:
- Create an activity with a gravity form image checklist
- View the form and make sure images and text are rendering properly