### PR TITLE
Add ability to filter nodes based on certain attributes

### DIFF
--- a/classes/class.tapestry-node.php
+++ b/classes/class.tapestry-node.php
@@ -251,7 +251,7 @@ class TapestryNode implements ITapestryNode
     {
         wp_update_post(array(
             'ID'            => $this->nodePostId,
-            'post_author'   => $this->author->id
+            'post_author'   => $this->author['id']
         ));
     }
 

--- a/classes/class.tapestry-node.php
+++ b/classes/class.tapestry-node.php
@@ -50,7 +50,7 @@ class TapestryNode implements ITapestryNode
         $this->nodePostId = 0;
         $this->nodeMetaId = (int) $nodeMetaId;
 
-        $this->author = wp_get_current_user()->ID;
+        $this->author = $this->_getAuthorInfo(wp_get_current_user()->ID);
         $this->conditions = [];
         $this->size = '';
         $this->title = '';
@@ -77,7 +77,7 @@ class TapestryNode implements ITapestryNode
         if (TapestryHelpers::isValidTapestryNode($this->nodeMetaId)) {
             $node = $this->_loadFromDatabase();
             $this->set($node);
-            $this->author = get_post_field( 'post_author', $this->nodePostId );
+            $this->author = $this->_getAuthorInfo(get_post_field( 'post_author', $this->nodePostId ));
         }
     }
 
@@ -251,7 +251,7 @@ class TapestryNode implements ITapestryNode
     {
         wp_update_post(array(
             'ID'            => $this->nodePostId,
-            'post_author'   => $this->author
+            'post_author'   => $this->author->id
         ));
     }
 
@@ -349,5 +349,14 @@ class TapestryNode implements ITapestryNode
             $nodeData->lockedImageURL = $nodeMetadata->meta_value->lockedImageURL;
         }
         return $nodeData;
+    }
+
+    private function _getAuthorInfo($id)
+    {
+        $user = get_user_by('id', $id);
+        return [
+            "id"    => $id,
+            "name"  => $user->display_name,
+        ];
     }
 }

--- a/templates/single-tapestry.php
+++ b/templates/single-tapestry.php
@@ -126,6 +126,7 @@ get_header(); ?>
             // thisTapestryTool.redraw(false);
 
             var wpPostId = "<?php echo get_the_ID(); ?>";
+            var wpUserId = "<?php echo apply_filters('determine_current_user', false); ?>";
             var apiUrl = "<?php echo get_rest_url(null, 'tapestry-tool/v1'); ?>";
             var adminAjaxUrl = "<?php echo admin_url('admin-ajax.php'); ?>";
 

--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -418,3 +418,7 @@ rect.selectable {
 .node-selected rect.selectable {
     fill-opacity: 0.7;
 }
+
+.node.unfiltered {
+    opacity: 0.7;
+}

--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -418,3 +418,9 @@ rect.selectable {
 .node-selected rect.selectable {
     fill-opacity: 0.7;
 }
+
+#depth-warning-message {
+    position: absolute;
+    top: calc(100% + 16px);
+    font-size: 0.9em;
+}

--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -418,7 +418,3 @@ rect.selectable {
 .node-selected rect.selectable {
     fill-opacity: 0.7;
 }
-
-.node.unfiltered {
-    opacity: 0.7;
-}

--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -67,6 +67,7 @@ body {
 
 #tapestry-controls-wrapper {
     margin: 40px 10% 20px;
+    margin-top: 0;
     padding: 10px 16px;
     float: right;
     width: auto;
@@ -79,7 +80,6 @@ body {
 @media (min-width:1000px) {
 	#tapestry-controls-wrapper {
 		position: absolute;
-		margin-top: -50px;
 		right: 0;
 	}
 }

--- a/templates/tapestry.css
+++ b/templates/tapestry.css
@@ -79,7 +79,7 @@ body {
 @media (min-width:1000px) {
 	#tapestry-controls-wrapper {
 		position: absolute;
-		margin-top: -60px;
+		margin-top: -50px;
 		right: 0;
 	}
 }

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -1814,8 +1814,7 @@ function tapestryTool(config){
     }
 
     function goToNode(nodeId) {
-        const base = location.origin + location.pathname + `#\/`;
-        location.href = base + `nodes/${nodeId}`
+        dispatchEvent(new CustomEvent("tapestry-open-node", { detail: { id: nodeId } }));
         recordAnalyticsEvent('user', 'open', 'lightbox', nodeId);
     }
 

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -661,38 +661,36 @@ function tapestryTool(config){
         AUTHOR: "author"
     }
 
-    this.updateVisibleNodes = () => {
-        const route = window.location.href.split(`#\/`)[1]
-        if (route.startsWith("filter")) {
-            const query = new URLSearchParams(route.split("filter")[1])
-            const attr = query.get("by")
-            const val = query.get("q")
-            if (attr && val) {
-                let newVisibleNodes = tapestry.dataset.nodes.filter(n => visibleNodes.has(n.id))
-                switch (attr) {
-                    case filterOptions.AUTHOR:
-                        newVisibleNodes = 
-                            tapestry.dataset.nodes.filter(n => n.author.id == val)
-                                .concat(tapestry.dataset.nodes.filter(n => n.author.id == wpUserId))
-                        break
-                    default:
-                        break
-                }
-                
-                // Only rerender the tapestry if the visible nodes changes
-                if (didVisibleNodesChange(newVisibleNodes)) {
-                    visibleNodes = new Set(newVisibleNodes.map(n => n.id))
-                    filterTapestry()
+    this.updateVisibleNodes = (to, from) => {
+        // Only update if we're moving from or to a filter route. This prevents
+        // unnecessary rerenders when opening lightboxes.
+        if (isFilterActive(to) || isFilterActive(from)) {
+            const route = window.location.href.split(`#\/`)[1]
+            let newVisibleNodes = tapestry.dataset.nodes.filter(n => visibleNodes.has(n.id))
+            if (route.startsWith("filter")) {
+                const query = new URLSearchParams(route.split("filter")[1])
+                const attr = query.get("by")
+                const val = query.get("q")
+                if (attr && val) {
+                    switch (attr) {
+                        case filterOptions.AUTHOR:
+                            newVisibleNodes = 
+                                tapestry.dataset.nodes.filter(n => n.author.id == val)
+                                    .concat(tapestry.dataset.nodes.filter(n => n.author.id == wpUserId))
+                            break
+                        default:
+                            break
+                    }
                 }
             }
-        }
+            visibleNodes = new Set(newVisibleNodes.map(n => n.id))
+            resizeNodes(root)
+        }   
     }
 
-    function didVisibleNodesChange(newNodes) {
-        if (newNodes.length !== visibleNodes.size) {
-            return true
-        }
-        return newNodes.some(n => !visibleNodes.has(n.id))
+    function isFilterActive(url = window.location.href) {
+        const route = url.split(`#\/`)[1]
+        return route.startsWith("filter")
     }
     
     /****************************************************
@@ -2275,18 +2273,25 @@ function tapestryTool(config){
         for (var i in tapestry.dataset.nodes) {
             var node = tapestry.dataset.nodes[i];
             var id = node.id;
-    
-            //NOTE: If there are any nodes are that fit two roles (ie: selected and the grandchild),
-            //      should default to being the more senior role
+
             if (id === root) {
                 node.nodeType = "root";
-            } else if (!tapestryDepth || children.indexOf(id) > -1) {
-                node.nodeType = "child";
-            } else if (grandchildren.indexOf(id) > -1) {
-                node.nodeType = "grandchild";
             } else {
-                node.nodeType = "";
+                //NOTE: If there are any nodes are that fit two roles (ie: selected and the grandchild),
+                //      should default to being the more senior role
+                // If a node is in the visible nodes list and a filter is active, 
+                // always set it as a child
+                if (isFilterActive() && visibleNodes.has(id)) {
+                    node.nodeType = "child";
+                } else if (!tapestryDepth || children.indexOf(id) > -1) {
+                    node.nodeType = "child";
+                } else if (grandchildren.indexOf(id) > -1) {
+                    node.nodeType = "grandchild";
+                } else {
+                    node.nodeType = "";
+                }
             }
+            
         }
     }
     
@@ -2396,6 +2401,11 @@ function tapestryTool(config){
     // ALL the checks for whether a certain node is viewable
     function getViewable(node) {
         if (!visibleNodes.has(node.id)) return false;
+
+        if (isFilterActive() && visibleNodes.has(node.id)) {
+            return true;
+        }
+
         // CHECK 1: If the node is currently in view (ie: root/child/grandchild)
         if (node.nodeType === "") return false;
 

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -303,6 +303,7 @@ function tapestryTool(config){
         links = createLinks();
         nodes = createNodes();
 
+        this.updateVisibleNodes();
         filterTapestry(true);
         
         //---------------------------------------------------
@@ -676,7 +677,6 @@ function tapestryTool(config){
                         case filterOptions.AUTHOR:
                             newVisibleNodes = 
                                 tapestry.dataset.nodes.filter(n => n.author.id == val)
-                                    .concat(tapestry.dataset.nodes.filter(n => n.author.id == wpUserId))
                             break
                         default:
                             break

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -440,6 +440,7 @@ function tapestryTool(config){
             // Every time the slider's value is changed, do the following
             tapestryDepthSlider.onchange = function() {
                 tapestryDepth = this.value;
+                updateDepthMessage();
             
                 setNodeTypes(root);
                 setLinkTypes(root);
@@ -449,6 +450,13 @@ function tapestryTool(config){
             };
             
             tapestryControlsDiv.appendChild(depthSliderWrapper);
+
+            const messageWrapper = document.createElement("p");
+            messageWrapper.id = "depth-warning-message";
+            messageWrapper.textContent = `Some filter results might be hidden because you're not at max depth.`;
+            messageWrapper.style.opacity = shouldShowMessage() ? "1" : "0";
+
+            tapestryControlsDiv.appendChild(messageWrapper);
 
             var showDepthSlider = findMaxDepth(root) >= 2;
             // Hide depth slider if depth is less than 3 
@@ -461,6 +469,15 @@ function tapestryTool(config){
         }
 
         return tapestryControlsDiv;
+    }
+
+    function updateDepthMessage() {
+        const messageWrapper = document.getElementById("depth-warning-message");
+        messageWrapper.style.opacity = shouldShowMessage() ? "1" : "0";
+    }
+
+    function shouldShowMessage() {
+        return tapestryDepthSlider.value !== tapestryDepthSlider.max && isFilterActive()
     }
     
     /****************************************************
@@ -2280,9 +2297,7 @@ function tapestryTool(config){
                 //      should default to being the more senior role
                 // If a node is in the visible nodes list and a filter is active, 
                 // always set it as a child
-                if (isFilterActive() && visibleNodes.has(id)) {
-                    node.nodeType = "child";
-                } else if (!tapestryDepth || children.indexOf(id) > -1) {
+                if (!tapestryDepth || children.indexOf(id) > -1) {
                     node.nodeType = "child";
                 } else if (grandchildren.indexOf(id) > -1) {
                     node.nodeType = "grandchild";

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -448,7 +448,8 @@ function tapestryTool(config){
                 filterTapestry();
                 updateSvgDimensions();
             };
-            
+
+            tapestryDepthSlider.value = tapestryDepth;
             tapestryControlsDiv.appendChild(depthSliderWrapper);
 
             const messageWrapper = document.createElement("p");

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -666,7 +666,7 @@ function tapestryTool(config){
         // unnecessary rerenders when opening lightboxes.
         if (isFilterActive(to) || isFilterActive(from)) {
             const route = window.location.href.split(`#\/`)[1]
-            let newVisibleNodes = tapestry.dataset.nodes.filter(n => visibleNodes.has(n.id))
+            let newVisibleNodes = tapestry.dataset.nodes
             if (route.startsWith("filter")) {
                 const query = new URLSearchParams(route.split("filter")[1])
                 const attr = query.get("by")
@@ -689,8 +689,10 @@ function tapestryTool(config){
     }
 
     function isFilterActive(url = window.location.href) {
-        const route = url.split(`#\/`)[1]
-        return route.startsWith("filter")
+        if (url.includes("#")) {
+            url = url.split(`#\/`)[1]
+        }
+        return url.includes("filter")
     }
     
     /****************************************************
@@ -1004,7 +1006,9 @@ function tapestryTool(config){
             .style("display", "block")
             .transition()
             .duration(TRANSITION_DURATION)
-            .style("opacity", "1");
+            .style("opacity", d => 
+                visibleNodes.has(d.source.id) && visibleNodes.has(d.target.id) ? "1" : "0.2"
+            );
     
         // Hide Links
     
@@ -1016,10 +1020,6 @@ function tapestryTool(config){
             .transition()
             .duration(TRANSITION_DURATION/2)
             .style("opacity", "0");
-        
-        setTimeout(function(){
-            linksToHide.style("display", "none");
-        }, TRANSITION_DURATION/2);
     
         // Show Nodes
     
@@ -1028,10 +1028,9 @@ function tapestryTool(config){
         });
     
         nodesToShow
-            .style("display", "block")
             .transition()
             .duration(TRANSITION_DURATION/2)
-            .style("opacity", "1");
+            .style("opacity", d => visibleNodes.has(d.id) ? "1" : "0.4");
         
         // Hide Nodes
     
@@ -1043,10 +1042,6 @@ function tapestryTool(config){
             .transition()
             .duration(TRANSITION_DURATION)
             .style("opacity", "0");
-    
-        setTimeout(function(){
-            nodesToHide.style("display", "none");
-        }, TRANSITION_DURATION);
         
         if (freshBuild) {
             buildNodeContents();
@@ -1425,7 +1420,7 @@ function tapestryTool(config){
     function rebuildNodeContents() {
         /* Remove text before transition animation */
         $(".meta").remove();
-    
+
         /* Commence transition animation */
         nodes.selectAll(".imageOverlay")
                 .transition()
@@ -2400,12 +2395,6 @@ function tapestryTool(config){
     
     // ALL the checks for whether a certain node is viewable
     function getViewable(node) {
-        if (!visibleNodes.has(node.id)) return false;
-
-        if (isFilterActive() && visibleNodes.has(node.id)) {
-            return true;
-        }
-
         // CHECK 1: If the node is currently in view (ie: root/child/grandchild)
         if (node.nodeType === "") return false;
 

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -1796,7 +1796,8 @@ function tapestryTool(config){
     }
 
     function goToNode(nodeId) {
-        location.href += `nodes/${nodeId}`
+        const base = location.origin + location.pathname + `#\/`;
+        location.href = base + `nodes/${nodeId}`
         recordAnalyticsEvent('user', 'open', 'lightbox', nodeId);
     }
 

--- a/templates/vue/src/App.vue
+++ b/templates/vue/src/App.vue
@@ -2,19 +2,19 @@
   <div id="app">
     <tapestry />
     <router-view></router-view>
+    <tapestry-filter />
   </div>
 </template>
 
 <script>
 import Tapestry from "./components/Tapestry"
+import TapestryFilter from "./components/TapestryFilter"
 
 export default {
   name: "app",
   components: {
     Tapestry,
-  },
-  data() {
-    return {}
+    TapestryFilter,
   },
 }
 </script>

--- a/templates/vue/src/App.vue
+++ b/templates/vue/src/App.vue
@@ -2,11 +2,12 @@
   <div id="app">
     <tapestry />
     <router-view></router-view>
-    <tapestry-filter />
+    <tapestry-filter v-if="tapestryIsLoaded" />
   </div>
 </template>
 
 <script>
+import { mapState } from "vuex"
 import Tapestry from "./components/Tapestry"
 import TapestryFilter from "./components/TapestryFilter"
 
@@ -15,6 +16,9 @@ export default {
   components: {
     Tapestry,
     TapestryFilter,
+  },
+  computed: {
+    ...mapState(["tapestryIsLoaded"]),
   },
 }
 </script>

--- a/templates/vue/src/components/Combobox.vue
+++ b/templates/vue/src/components/Combobox.vue
@@ -79,12 +79,19 @@ export default {
         return this.options
       }
 
-      const options = this.options.filter(option => {
-        return (
-          option[this.itemValue] === this.inputValue ||
-          option[this.itemText].toLowerCase().includes(this.inputValue.toLowerCase())
-        )
-      })
+      const options =
+        this.itemValue && this.itemText
+          ? this.options.filter(option => {
+              return (
+                option[this.itemValue] === this.inputValue ||
+                option[this.itemText]
+                  .toLowerCase()
+                  .includes(this.inputValue.toLowerCase())
+              )
+            })
+          : this.options.filter(text =>
+              text.toLowerCase().includes(this.inputValue.toLowerCase())
+            )
       return options.length
         ? options.length > MAX_OPTIONS_LENGTH
           ? options.slice(0, MAX_OPTIONS_LENGTH)
@@ -114,7 +121,7 @@ export default {
     },
     handleClick(option) {
       this.$emit("input", this.getValue(option))
-      this.inputValue = option[this.itemText]
+      this.inputValue = this.itemText ? option[this.itemText] : option
       this.selected = true
       this.$refs.input.blur()
     },

--- a/templates/vue/src/components/Combobox.vue
+++ b/templates/vue/src/components/Combobox.vue
@@ -1,8 +1,10 @@
 <template>
-  <b-form-group>
+  <div>
     <b-form-input
       ref="input"
       v-model="inputValue"
+      :size="size"
+      :style="inputStyle"
       @blur="handleBlur"
       @focus="handleFocus"
     ></b-form-input>
@@ -22,7 +24,7 @@
         <p>{{ emptyMessage }}</p>
       </div>
     </div>
-  </b-form-group>
+  </div>
 </template>
 
 <script>
@@ -54,6 +56,16 @@ export default {
       type: String,
       required: false,
       default: "Please add at least one option.",
+    },
+    size: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
+    inputStyle: {
+      type: Object,
+      required: false,
+      default: () => ({}),
     },
   },
   data() {

--- a/templates/vue/src/components/Combobox.vue
+++ b/templates/vue/src/components/Combobox.vue
@@ -101,9 +101,7 @@ export default {
   },
   watch: {
     text(newText) {
-      if (this.inputValue.length === 0) {
-        this.inputValue = newText
-      }
+      this.inputValue = newText
     },
   },
   created() {

--- a/templates/vue/src/components/Combobox.vue
+++ b/templates/vue/src/components/Combobox.vue
@@ -112,12 +112,14 @@ export default {
   methods: {
     handleBlur() {
       this.isOpen = false
-      // if user leaves focus and input is empty, clear the value
-      if (this.inputValue.length === 0) {
-        this.$emit("input", null)
-      } else if (this.inputValue !== this.text && !this.selected) {
-        this.inputValue = this.text
-      }
+      this.$nextTick(() => {
+        // if user leaves focus and input is empty, clear the value
+        if (this.inputValue.length === 0) {
+          this.$emit("input", null)
+        } else if (this.inputValue !== this.text && !this.selected) {
+          this.inputValue = this.text
+        }
+      })
     },
     handleClick(option) {
       this.$emit("input", this.getValue(option))

--- a/templates/vue/src/components/Lightbox.vue
+++ b/templates/vue/src/components/Lightbox.vue
@@ -174,7 +174,7 @@ export default {
       this.updateMayUnlockNodes(this.nodeId)
     },
     close() {
-      this.$router.push("/")
+      this.$router.go(-1)
     },
     handleLoad(dimensions) {
       if (dimensions) {

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -270,7 +270,7 @@
             </b-form-group>
           </div>
         </b-tab>
-        <b-tab title="Access" v-if="viewAccess">
+        <b-tab v-if="viewAccess" title="Access">
           <h6 class="mb-3 text-muted">General Permissions</h6>
           <div id="modal-permissions">
             <b-table-simple class="text-center" striped responsive>
@@ -545,11 +545,13 @@ export default {
       })
       return ordered
     },
-    viewAccess(){
-      return this.settings.showAccess === undefined ? 
-        true : this.settings.showAccess ?
-        true : wpData.wpCanEditTapestry !== ""
-    }
+    viewAccess() {
+      return this.settings.showAccess === undefined
+        ? true
+        : this.settings.showAccess
+        ? true
+        : wpData.wpCanEditTapestry !== ""
+    },
   },
   watch: {
     nodeImageUrl() {

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -497,7 +497,6 @@ export default {
     },
   },
   async mounted() {
-    console.log(this.node.permissions)
     this.gravityFormExists = await GravityFormsApi.exists()
     this.mediaTypes.push({
       value: "gravity-form",

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -497,7 +497,10 @@ export default {
     nodeData() {
       return [
         { name: "title", value: this.node.title },
-        { name: "conditions", value: this.lockNode ? this.node.conditions || [] : [] },
+        {
+          name: "conditions",
+          value: this.lockNode ? this.node.conditions || [] : [],
+        },
         { name: "description", value: this.node.description },
         { name: "behaviour", value: this.node.behaviour },
         { name: "mediaType", value: this.nodeType },

--- a/templates/vue/src/components/SettingsModal.vue
+++ b/templates/vue/src/components/SettingsModal.vue
@@ -147,13 +147,13 @@ export default {
     },
     permissionsOrder: {
       type: Array,
-      required: true
+      required: true,
     },
     initialDefault: {
       type: Object,
       required: false,
       default: () => ({}),
-    }
+    },
   },
   data() {
     return {

--- a/templates/vue/src/components/SettingsModal.vue
+++ b/templates/vue/src/components/SettingsModal.vue
@@ -130,6 +130,8 @@
 <script>
 import { mapGetters } from "vuex"
 import FileUpload from "./FileUpload"
+import Helpers from "@/utils/Helpers"
+
 export default {
   name: "settings-modal",
   components: {

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -20,8 +20,8 @@
       ></b-spinner>
       <b-spinner type="grow" variant="danger" small style="margin: 5px;"></b-spinner>
     </div>
-    <settings-modal 
-      :wp-can-edit-tapestry="wpCanEditTapestry" 
+    <settings-modal
+      :wp-can-edit-tapestry="wpCanEditTapestry"
       :permissions-order="permissionsOrder"
       :initial-default="populatedNode.permissions"
     />

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -81,7 +81,13 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(["selectedNode", "tapestry", "getNode", "getDirectParents", "settings"]),
+    ...mapGetters([
+      "selectedNode",
+      "tapestry",
+      "getNode",
+      "getDirectParents",
+      "settings",
+    ]),
     showRootNodeButton: function() {
       return (
         this.tapestryLoaded &&
@@ -167,10 +173,12 @@ export default {
         hideMedia: false,
         skippable: true,
         fullscreen: false,
-        permissions: this.settings.defaultPermissions ? this.settings.defaultPermissions : {
-          public: ["read"],
-          authenticated: ["read"],
-        },
+        permissions: this.settings.defaultPermissions
+          ? this.settings.defaultPermissions
+          : {
+              public: ["read"],
+              authenticated: ["read"],
+            },
         description: "",
         quiz: [],
         childOrdering: [],

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -139,6 +139,7 @@ export default {
     window.addEventListener("add-new-node", this.addNewNode)
     window.addEventListener("edit-node", this.editNode)
     window.addEventListener("tapestry-updated", this.tapestryUpdated)
+    window.addEventListener("tapestry-open-node", this.openNode)
   },
   methods: {
     ...mapMutations([
@@ -149,6 +150,9 @@ export default {
       "updateNodeCoordinates",
     ]),
     ...mapActions(["addNode", "addLink", "updateNode", "updateNodePermissions"]),
+    openNode({ detail: { id } }) {
+      this.$router.push(`/nodes/${id}`)
+    },
     tapestryUpdated(event) {
       if (!this.tapestryLoaded) {
         event.detail.dataset["favourites"] = this.favourites

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -12,9 +12,11 @@
       ></combobox>
       <combobox
         v-if="isFilterSelected"
-        :options="comboboxValueOptions"
         item-text="name"
         item-value="id"
+        :options="comboboxValueOptions"
+        :value="activeFilterValue"
+        @input="updateFilterValue"
       >
         <template v-slot="slotProps">
           <p>
@@ -55,6 +57,9 @@ export default {
     comboboxFilterOptions() {
       return Object.values(filterOptions)
     },
+    activeFilterValue() {
+      return this.$route.query.q || null
+    },
     comboboxValueOptions() {
       switch (this.activeFilterOption) {
         case filterOptions.AUTHOR: {
@@ -74,6 +79,10 @@ export default {
     },
     updateFilterOption(opt) {
       this.$router.replace({ query: opt ? { by: opt } : {} })
+    },
+    updateFilterValue(val) {
+      const newQuery = val ? { ...this.$route.query, q: val } : this.$route.query
+      this.$router.replace({ query: newQuery })
     },
   },
 }

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -10,11 +10,25 @@
         :value="activeFilterOption"
         @input="updateFilterOption"
       ></combobox>
+      <combobox
+        v-if="isFilterSelected"
+        :options="comboboxValueOptions"
+        item-text="name"
+        item-value="id"
+      >
+        <template v-slot="slotProps">
+          <p>
+            <code>{{ slotProps.option.id }}</code>
+            {{ slotProps.option.name }}
+          </p>
+        </template>
+      </combobox>
     </div>
   </div>
 </template>
 
 <script>
+import { mapState } from "vuex"
 import Combobox from "./Combobox"
 
 const filterOptions = {
@@ -27,6 +41,7 @@ export default {
     Combobox,
   },
   computed: {
+    ...mapState(["nodes"]),
     isActive() {
       return this.$route.path.includes("filter")
     },
@@ -39,6 +54,18 @@ export default {
     },
     comboboxFilterOptions() {
       return Object.values(filterOptions)
+    },
+    comboboxValueOptions() {
+      switch (this.activeFilterOption) {
+        case filterOptions.AUTHOR: {
+          const authors = new Map(
+            this.nodes.map(node => [node.author.id, node.author])
+          )
+          return Array.from(authors.values())
+        }
+        default:
+          return []
+      }
     },
   },
   methods: {

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -79,6 +79,11 @@ export default {
       }
     },
   },
+  watch: {
+    $route() {
+      thisTapestryTool.updateVisibleNodes()
+    },
+  },
   methods: {
     toggleFilter() {
       this.isActive

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -1,14 +1,22 @@
 <template>
-  <h1>I'm a filter</h1>
+  <button class="filter"><i class="fas fa-search"></i></button>
 </template>
 
 <script>
 export default {
   name: "tapestry-filter",
-  watch: {
-    $route(to, from) {
-      console.log(to, from)
+  computed: {
+    isActive() {
+      return this.$route.path.includes("filter")
     },
   },
 }
 </script>
+
+<style lang="scss" scoped>
+.filter {
+  position: absolute;
+  top: -60px;
+  left: 10vw;
+}
+</style>

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -123,7 +123,7 @@ export default {
 .filter {
   display: flex;
   position: absolute;
-  top: -50px;
+  top: 0;
   left: 10vw;
   height: 32px;
 

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -1,15 +1,44 @@
 <template>
-  <button class="filter">
-    <i class="fas fa-search"></i>
-  </button>
+  <div class="filter">
+    <button>
+      <i class="fas fa-search"></i>
+    </button>
+    <combobox
+      v-if="isActive"
+      :options="comboboxFilterOptions"
+      :value="activeFilterOption"
+      @input="updateFilterOption"
+    ></combobox>
+  </div>
 </template>
 
 <script>
+import Combobox from "./Combobox"
+
+const filterOptions = {
+  AUTHOR: "author",
+}
+
 export default {
   name: "tapestry-filter",
+  components: {
+    Combobox,
+  },
   computed: {
     isActive() {
       return this.$route.path.includes("filter")
+    },
+    activeFilterOption() {
+      const query = this.$route.query
+      return query.by || null
+    },
+    comboboxFilterOptions() {
+      return Object.values(filterOptions)
+    },
+  },
+  methods: {
+    updateFilterOption(opt) {
+      this.$router.replace({ query: opt ? { by: opt } : {} })
     },
   },
 }

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -3,11 +3,13 @@
     <button @click="toggleFilter">
       <i class="fas fa-search"></i>
     </button>
-    <div v-if="isActive">
-      <p>Filter by:</p>
+    <div :class="['input-container', { 'input-container-show': isActive }]">
       <combobox
+        class="filter-combobox"
         :options="comboboxFilterOptions"
         :value="activeFilterOption"
+        :input-style="inputStyles"
+        size="sm"
         @input="updateFilterOption"
       >
         <template v-slot="slotProps">
@@ -18,10 +20,13 @@
       </combobox>
       <combobox
         v-if="isFilterSelected"
+        class="filter-combobox"
         item-text="name"
         item-value="id"
         :options="comboboxValueOptions"
         :value="activeFilterValue"
+        :input-style="inputStyles"
+        size="sm"
         @input="updateFilterValue"
       >
         <template v-slot="slotProps">
@@ -50,6 +55,12 @@ export default {
   },
   computed: {
     ...mapState(["nodes"]),
+    inputStyles() {
+      return {
+        borderRadius: "4px",
+        width: "60%",
+      }
+    },
     isActive() {
       return this.$route.path.includes("filter")
     },
@@ -111,8 +122,48 @@ export default {
 
 <style lang="scss" scoped>
 .filter {
+  display: flex;
   position: absolute;
-  top: -60px;
+  top: -50px;
   left: 10vw;
+  height: 32px;
+
+  button {
+    color: #999;
+    padding: 0;
+    margin-right: 12px;
+    background: #fbfbfb;
+    box-shadow: 0 0 7px 0 #ddd;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    font-size: 0.8em;
+    transform: translateY(-4px);
+
+    &:hover {
+      color: #11a6d8;
+    }
+  }
+
+  .filter-combobox {
+    margin-right: 8px;
+    &:last-child {
+      transform: translateX(-40%);
+    }
+  }
+}
+
+.input-container {
+  display: flex;
+  opacity: 0;
+  transform: translateX(-32px);
+  transition: all 0.4s ease-in;
+  pointer-events: none;
+
+  &-show {
+    opacity: 1;
+    transform: translateX(0);
+    pointer-events: all;
+  }
 }
 </style>

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -19,7 +19,6 @@
         </template>
       </combobox>
       <combobox
-        v-if="isFilterSelected"
         class="filter-combobox"
         item-text="name"
         item-value="id"

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -81,7 +81,10 @@ export default {
   },
   watch: {
     $route(to, from) {
-      thisTapestryTool.updateVisibleNodes(to, from)
+      thisTapestryTool.updateVisibleNodes(
+        to.fullPath.slice(1),
+        from.fullPath.slice(1)
+      )
     },
   },
   methods: {

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -9,7 +9,13 @@
         :options="comboboxFilterOptions"
         :value="activeFilterOption"
         @input="updateFilterOption"
-      ></combobox>
+      >
+        <template v-slot="slotProps">
+          <p class="filter-value">
+            {{ slotProps.option }}
+          </p>
+        </template>
+      </combobox>
       <combobox
         v-if="isFilterSelected"
         item-text="name"
@@ -19,7 +25,7 @@
         @input="updateFilterValue"
       >
         <template v-slot="slotProps">
-          <p>
+          <p class="filter-value">
             <code>{{ slotProps.option.id }}</code>
             {{ slotProps.option.name }}
           </p>
@@ -66,7 +72,7 @@ export default {
           const authors = new Map(
             this.nodes.map(node => [node.author.id, node.author])
           )
-          return Array.from(authors.values())
+          return [...authors.values()]
         }
         default:
           return []
@@ -80,10 +86,15 @@ export default {
         : this.$router.push(`/filter?by=${this.comboboxFilterOptions[0]}`)
     },
     updateFilterOption(opt) {
-      this.$router.replace({ query: opt ? { by: opt } : {} })
+      this.$router.replace({
+        query: { by: opt !== null ? opt : this.comboboxFilterOptions[0] },
+      })
     },
     updateFilterValue(val) {
-      const newQuery = val ? { ...this.$route.query, q: val } : this.$route.query
+      const newQuery =
+        val !== null
+          ? { ...this.$route.query, q: val }
+          : { by: this.$route.query.by }
       this.$router.replace({ query: newQuery })
     },
   },

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -75,7 +75,9 @@ export default {
   },
   methods: {
     toggleFilter() {
-      this.isActive ? this.$router.go(-1) : this.$router.push("/filter")
+      this.isActive
+        ? this.$router.go(-1)
+        : this.$router.push(`/filter?by=${this.comboboxFilterOptions[0]}`)
     },
     updateFilterOption(opt) {
       this.$router.replace({ query: opt ? { by: opt } : {} })

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -1,0 +1,14 @@
+<template>
+  <h1>I'm a filter</h1>
+</template>
+
+<script>
+export default {
+  name: "tapestry-filter",
+  watch: {
+    $route(to, from) {
+      console.log(to, from)
+    },
+  },
+}
+</script>

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -1,14 +1,16 @@
 <template>
   <div class="filter">
-    <button>
+    <button @click="toggleFilter">
       <i class="fas fa-search"></i>
     </button>
-    <combobox
-      v-if="isActive"
-      :options="comboboxFilterOptions"
-      :value="activeFilterOption"
-      @input="updateFilterOption"
-    ></combobox>
+    <div v-if="isActive">
+      <p>Filter by:</p>
+      <combobox
+        :options="comboboxFilterOptions"
+        :value="activeFilterOption"
+        @input="updateFilterOption"
+      ></combobox>
+    </div>
   </div>
 </template>
 
@@ -28,6 +30,9 @@ export default {
     isActive() {
       return this.$route.path.includes("filter")
     },
+    isFilterSelected() {
+      return this.activeFilterOption !== null
+    },
     activeFilterOption() {
       const query = this.$route.query
       return query.by || null
@@ -37,6 +42,9 @@ export default {
     },
   },
   methods: {
+    toggleFilter() {
+      this.isActive ? this.$router.go(-1) : this.$router.push("/filter")
+    },
     updateFilterOption(opt) {
       this.$router.replace({ query: opt ? { by: opt } : {} })
     },

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -104,7 +104,7 @@ export default {
         : this.$router.push(`/filter?by=${this.comboboxFilterOptions[0]}`)
     },
     updateFilterOption(opt) {
-      this.$router.replace({
+      this.$router.push({
         query: { by: opt !== null ? opt : this.comboboxFilterOptions[0] },
       })
     },
@@ -113,7 +113,7 @@ export default {
         val !== null
           ? { ...this.$route.query, q: val }
           : { by: this.$route.query.by }
-      this.$router.replace({ query: newQuery })
+      this.$router.push({ query: newQuery })
     },
   },
 }

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -80,8 +80,8 @@ export default {
     },
   },
   watch: {
-    $route() {
-      thisTapestryTool.updateVisibleNodes()
+    $route(to, from) {
+      thisTapestryTool.updateVisibleNodes(to, from)
     },
   },
   methods: {

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -1,5 +1,7 @@
 <template>
-  <button class="filter"><i class="fas fa-search"></i></button>
+  <button class="filter">
+    <i class="fas fa-search"></i>
+  </button>
 </template>
 
 <script>

--- a/templates/vue/src/components/lightbox/H5PIframe.vue
+++ b/templates/vue/src/components/lightbox/H5PIframe.vue
@@ -9,9 +9,7 @@
 </template>
 
 <script>
-import TapestryApi from "@/services/TapestryAPI"
 import Helpers from "@/utils/Helpers"
-import { mapActions } from "vuex"
 
 const ALLOW_SKIP_THRESHOLD = 0.95
 

--- a/templates/vue/src/components/lightbox/quiz-screen/Question.vue
+++ b/templates/vue/src/components/lightbox/quiz-screen/Question.vue
@@ -64,7 +64,6 @@
           </answer-button>
         </div>
       </div>
-      </div>
     </div>
   </div>
 </template>
@@ -317,5 +316,4 @@ button {
     }
   }
 }
-
 </style>

--- a/templates/vue/src/router.js
+++ b/templates/vue/src/router.js
@@ -1,7 +1,6 @@
 import Vue from "vue"
 import VueRouter from "vue-router"
 import Lightbox from "./components/Lightbox"
-import TapestryFilter from "./components/TapestryFilter"
 
 Vue.use(VueRouter)
 
@@ -9,16 +8,6 @@ const routes = [
   {
     path: "/nodes/:nodeId",
     component: Lightbox,
-    props: true,
-  },
-  {
-    path: "/filter",
-    component: TapestryFilter,
-    props: true,
-  },
-  {
-    path: "/",
-    component: TapestryFilter,
     props: true,
   },
 ]

--- a/templates/vue/src/router.js
+++ b/templates/vue/src/router.js
@@ -1,6 +1,7 @@
 import Vue from "vue"
 import VueRouter from "vue-router"
 import Lightbox from "./components/Lightbox"
+import TapestryFilter from "./components/TapestryFilter"
 
 Vue.use(VueRouter)
 
@@ -8,6 +9,16 @@ const routes = [
   {
     path: "/nodes/:nodeId",
     component: Lightbox,
+    props: true,
+  },
+  {
+    path: "/filter",
+    component: TapestryFilter,
+    props: true,
+  },
+  {
+    path: "/",
+    component: TapestryFilter,
     props: true,
   },
 ]

--- a/templates/vue/src/store/actions.js
+++ b/templates/vue/src/store/actions.js
@@ -18,7 +18,7 @@ export async function addNode({ commit }, newNode) {
 
   const nodeToAdd = { ...newNode }
   nodeToAdd.id = response.data.id
-  nodeToAdd.author = wpData.wpUserId
+  nodeToAdd.author = response.data.author
 
   commit("addNode", nodeToAdd)
   return nodeToAdd.id


### PR DESCRIPTION
Closes #478

**General Filtering**

- [x] Add filter component that computes filters based on current window URL
- [x] Should have two dropdowns: one for selecting which attribute to filter on, and the other the attribute value
- [x] On the D3 side, watch for changes in the window URL and update viewable nodes based on this filter

**Filtering by Author**

- [x] Save author information when node is created

**Testing**

- Create a new Tapestry as an admin
  - Make sure that either your default permissions allow add access for authenticated users or when you're adding a node that node has add access
- Login as another user
- Add some nodes
- Press the search button on the top left corner
- On the second combobox, select between the users
- The nodes not made by the user should have lower opacity (unless they're your nodes)