### PR TITLE
Unchecking checkboxes in authoring tool should clear corresponding content (TYDE)

### DIFF
--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -347,7 +347,7 @@
             </b-table-simple>
           </div>
           <h6 class="mt-4 mb-3 text-muted">Lock Node</h6>
-          <conditions-form :node="node" />
+          <conditions-form :node="node" @changed="lockNode = $event" />
         </b-tab>
         <b-tab
           v-if="node.mediaType === 'h5p' || node.mediaType === 'video'"
@@ -594,6 +594,7 @@ export default {
         { value: "activity", text: "Activity" },
         { value: "accordion", text: "Accordion" },
       ],
+      lockNode: false,
       gravityFormExists: false,
       gravityFormOptions: [],
       h5pContentOptions: [],
@@ -675,7 +676,7 @@ export default {
     nodeData() {
       return [
         { name: "title", value: this.node.title },
-        { name: "conditions", value: this.node.conditions || [] },
+        { name: "conditions", value: this.lockNode ? this.node.conditions || [] : [] },
         { name: "description", value: this.node.description },
         { name: "behaviour", value: this.node.behaviour },
         { name: "mediaType", value: this.nodeType },
@@ -690,11 +691,11 @@ export default {
         { name: "mediaDuration", value: this.node.mediaDuration },
         {
           name: "imageURL",
-          value: this.node.imageURL || "",
+          value: this.addThumbnail ? this.node.imageURL || "" : "",
         },
         {
           name: "lockedImageURL",
-          value: this.node.lockedImageURL || "",
+          value: this.addLockedThumbnail ? this.node.lockedImageURL || "" : "",
         },
         { name: "permissions", value: this.node.permissions },
         { name: "hideTitle", value: this.node.hideTitle },
@@ -736,12 +737,6 @@ export default {
         { name: "childOrdering", value: this.node.childOrdering },
       ]
     },
-    nodeImageUrl() {
-      return this.node.imageURL
-    },
-    nodeLockedImageURL() {
-      return this.node.lockedImageURL
-    },
     newPermissions() {
       const last = this.permissionsOrder[this.permissionsOrder.length - 1]
       return [...this.node.permissions[last]]
@@ -755,13 +750,6 @@ export default {
     },
   },
   watch: {
-    nodeImageUrl() {
-      this.addThumbnail = this.node.imageURL && this.node.imageURL.length > 0
-    },
-    nodeLockedImageURL() {
-      this.addLockedThumbnail =
-        this.node.lockedImageURL && this.node.lockedImageURL.length > 0
-    },
     selectedH5pContent() {
       this.node.typeData.mediaURL = this.getMediaUrl()
     },
@@ -798,6 +786,9 @@ export default {
           this.selectedGravityFormContent = selectedForm ? selectedForm.id : ""
         }
         this.selectedH5pContent = selectedContent ? selectedContent.id : ""
+        this.lockNode = this.node.conditions && this.node.conditions.length > 0
+        this.addThumbnail = this.node.imageURL.length > 0
+        this.addLockedThumbnail = this.node.lockedImageURL.length > 0
       }
     })
     this.$root.$on("bv::modal::hide", (_, modalId) => {

--- a/templates/vue/src/components/node-modal/ConditionsForm.vue
+++ b/templates/vue/src/components/node-modal/ConditionsForm.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <b-form-group class="mb-3">
-      <b-form-checkbox v-model="lock" @change="disableConditions">
+      <b-form-checkbox v-model="lock" @change="$emit('changed', !lock)">
         Prevent access until specified conditions are met
       </b-form-checkbox>
     </b-form-group>
@@ -96,11 +96,6 @@ export default {
     },
     removeCondition(idx) {
       this.conditions.splice(idx, 1)
-    },
-    disableConditions() {
-      if (this.lock) {
-        this.conditions = []
-      }
     },
   },
 }


### PR DESCRIPTION
* If checkbox is unchecked and the node form is submitted, it should clear the fields that disappear when unchecking it
* Ensure that checkbox can be re-checked before submitting form to retrieve settings
* Applies to "Add thumbnail", "Add a different thumbnail for locked node", and "Lock node"