### PR TITLE
Version 2.25.0 bump, bug fixes, and improvements

### DIFF
--- a/tapestry.php
+++ b/tapestry.php
@@ -9,7 +9,7 @@
  */
 
 // Used to force-refresh assets 
-$TAPESTRY_VERSION_NUMBER = '2.23.0-beta';
+$TAPESTRY_VERSION_NUMBER = '2.25.0-beta';
 
 // Set this to false if you want to use the Vue build instead of npm dev
 $TAPESTRY_USE_DEV_MODE = TRUE;

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -104,7 +104,7 @@ function tapestryTool(config){
             for (var i=0; i<tapestry.dataset.nodes.length; i++) {
 
                 // change http(s):// to // in media URLs
-                if (typeof tapestry.dataset.nodes[i].typeData != "undefined" && typeof tapestry.dataset.nodes[i].typeData.mediaURL != "undefined" && tapestry.dataset.nodes[i].typeData.mediaURL.length > 0) {
+                if (typeof tapestry.dataset.nodes[i].typeData != "undefined" && typeof tapestry.dataset.nodes[i].typeData.mediaURL && tapestry.dataset.nodes[i].typeData.mediaURL.length > 0) {
                     tapestry.dataset.nodes[i].typeData.mediaURL = tapestry.dataset.nodes[i].typeData.mediaURL.replace(/(http(s?)):\/\//gi, '//');
                 }
 
@@ -609,7 +609,7 @@ function tapestryTool(config){
                 }
             });
         } else if (getChildren(nodeId, 0) && getChildren(nodeId, 0).length > 1) {
-            alert("Can only delete nodes with one neighbouring node.");
+            alert("Cannot delete this node. \n\nOnly nodes with a single connection can be deleted.");
         } else {
             $.ajax({
                 url: apiUrl + "/tapestries/" + config.wpPostId + "/nodes/" + nodeId,
@@ -1945,8 +1945,8 @@ function tapestryTool(config){
             return hardCodedDimensions;
         }
 
-        var tapestryWidth = $('#'+TAPESTRY_CONTAINER_ID).outerWidth();
-        var tapestryHeight = getBrowserHeight() - $('#'+TAPESTRY_CONTAINER_ID).offset().top;
+        var tapestryWidth = document.getElementById(TAPESTRY_CONTAINER_ID).offsetWidth;
+        var tapestryHeight = getBrowserHeight() - document.getElementById(TAPESTRY_CONTAINER_ID).offsetTop;
         var tapestryStartX = 0;
         var tapestryStartY = 0;
 
@@ -1970,7 +1970,7 @@ function tapestryTool(config){
         // but kept the same way on mobile phones where the browser is vertically longer
         // Note: Disabled for authors because it doesn't allow the author to lay out the tapestry the way
         // they want to while drafting a tapestry if we keep transposing it
-        if (!config.wpCanEditTapestry) {
+        if (!config.wpCanEditTapestry && tapestry.dataset.settings.nodeDraggable === false) {
             var tapestryAspectRatio = nodeDimensions.x / nodeDimensions.y;
             var windowAspectRatio = getAspectRatio();
             if (tapestryAspectRatio > 1 && windowAspectRatio < 1 || tapestryAspectRatio < 1 && windowAspectRatio > 1) {

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -367,11 +367,12 @@ export default {
           if (data) {
             newNodeEntry.typeData.linkMetadata = data
 
-            if (newNodeEntry.imageURL && confirm("Would you like to use the link preview image as the thumbnail image?")) {
+            if (newNodeEntry.imageURL && 
+                confirm("Would you like to use the link preview image as the thumbnail image?")) {
               newNodeEntry.imageURL = data.image
             }
-
-            if (newNodeEntry.lockedImageUR && confirm("Would you like to use the link preview image as the locked thumbnail image?")) {
+            if (newNodeEntry.lockedImageUR && 
+                confirm("Would you like to use the link preview image as the locked thumbnail image?")) {
               newNodeEntry.lockedImageURL = data.image
             }
           }

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -363,23 +363,17 @@ export default {
         ) {
           const url = newNodeEntry.typeData.mediaURL
           const { data } = await getLinkMetadata(url)
-          newNodeEntry.typeData.linkMetadata = data
 
-          let shouldChange = true
-          if (newNodeEntry.imageURL) {
-            shouldChange = confirm("Change thumbnail to new image?")
-          }
+          if (data) {
+            newNodeEntry.typeData.linkMetadata = data
 
-          if (shouldChange) {
-            newNodeEntry.imageURL = data.image
-          }
+            if (newNodeEntry.imageURL && confirm("Would you like to use the link preview image as the thumbnail image?")) {
+              newNodeEntry.imageURL = data.image
+            }
 
-          if (newNodeEntry.lockedImageURL) {
-            shouldChange = confirm("Change locked thumbnail to new image?")
-          }
-
-          if (shouldChange) {
-            newNodeEntry.lockedImageURL = data.image
+            if (newNodeEntry.lockedImageUR && confirm("Would you like to use the link preview image as the locked thumbnail image?")) {
+              newNodeEntry.lockedImageURL = data.image
+            }
           }
         }
       }

--- a/templates/vue/src/services/LinkPreviewApi.js
+++ b/templates/vue/src/services/LinkPreviewApi.js
@@ -8,6 +8,11 @@ export async function getLinkMetadata(url) {
   const endpoint = `${API_URL}/?key=${LINK_PREVIEW_API_KEY}&q=${Helpers.normalizeUrl(
     url
   )}`
-  const { data } = await axios.get(endpoint)
-  return { data }
+  try {
+    const { data } = await axios.get(endpoint)
+    return { data }
+  } catch (Error) {
+    console.error("Link preview could not be retrieved", Error)
+    return []
+  }
 }


### PR DESCRIPTION
- Bug fix: Tapestry stuck on "Loading..." screen until refreshed
- Bug fix: Removed media URL causes Tapestry not to load
- Bug fix: Moving nodes when not logged in transposes tapestry rapidly
- Bug fix: Unable to add external link if link preview fetch fails
- Wording improvement: Update thumbnail image to link preview image
- Wording improvement: Node deletion failure error message