### PR TITLE
Add analytics (TYDE)

### DIFF
--- a/endpoints.php
+++ b/endpoints.php
@@ -269,6 +269,13 @@ $REST_API_ENDPOINTS = [
             'methods'   => $REST_API_GET_METHOD,
             'callback'  => function() { wp_logout(); }
         ]
+    ],
+    'ANALYTICS' => (object) [
+        'ROUTE' => '/analytics',
+        'ARGUMENTS' => [
+            'methods'   => $REST_API_POST_METHOD,
+            'callback'  => 'saveAnalytics'
+        ]
     ]
 ];
 
@@ -286,6 +293,38 @@ foreach ($REST_API_ENDPOINTS as $ENDPOINT) {
             );
         }
     );
+}
+
+function saveAnalytics($request)
+{
+    global $wpdb;
+    $body = json_decode($request->get_body());
+
+	$actor = $body->actor;
+	$action = $body->action;
+	$object = $body->object;
+	$user_guid = $body->user_guid;
+	$object_id = $body->object_id;
+	$details = $body->details;
+
+    $table_name = $wpdb->prefix . "tapestry_analytics_events";
+
+	$success = $wpdb->insert( 
+		$table_name, 
+		array( 
+			'actor' => $actor, 
+			'action' => $action, 
+			'object' => $object, 
+			'user_guid' => $user_guid, 
+			'object_id' => $object_id, 
+			'details' => $details
+		) 
+    );
+    
+    if (!$success) {
+        return new WP_Error('fail_add_analytics', 'Failed to save analytics data', array('status' => 500));
+    }
+    return new WP_REST_Response(null, 201);
 }
 
 function login($request)

--- a/tapestry.php
+++ b/tapestry.php
@@ -229,36 +229,6 @@ function create_analytics_schema() {
     dbDelta( $sql );
 }
 
-add_action( 'wp_ajax_tapestry_log_analytics_event', 'tapestry_log_analytics_event' );
-add_action( 'wp_ajax_nopriv_tapestry_log_analytics_event', 'tapestry_log_analytics_event' );
-function tapestry_log_analytics_event() {
-
-	global $wpdb;
-
-	$actor = $_POST['actor'];
-	$action = $_POST['action2'];
-	$object = $_POST['object'];
-	$user_guid = $_POST['user_guid'];
-	$object_id = $_POST['object_id'];
-	$details = $_POST['details'];
-
-    $table_name = $wpdb->prefix . "tapestry_analytics_events";
-
-	$wpdb->insert( 
-		$table_name, 
-		array( 
-			'actor' => $actor, 
-			'action' => $action, 
-			'object' => $object, 
-			'user_guid' => $user_guid, 
-			'object_id' => $object_id, 
-			'details' => $details
-		) 
-	);
-
-	wp_die();
-}
-
 // TYDE CUSTOMIZATIONS
 
 register_activation_hook( __FILE__, 'tapestry_activation' );

--- a/templates/single-tapestry.php
+++ b/templates/single-tapestry.php
@@ -151,6 +151,7 @@ get_header(); ?>
             var apiUrl = "<?php echo get_rest_url(null, 'tapestry-tool/v1'); ?>";
             var adminAjaxUrl = "<?php echo admin_url('admin-ajax.php'); ?>";
 
+            var globals = { recordAnalyticsEvent }
             /****************************************************
              * ANALYTICS FUNCTIONS
              ****************************************************/

--- a/templates/single-tapestry.php
+++ b/templates/single-tapestry.php
@@ -177,9 +177,8 @@ get_header(); ?>
                 details['user-ip'] = $('#user-ip').text();
 
                 var data = {
-                    'action': 'tapestry_log_analytics_event',
                     'actor': actor,
-                    'action2': action,
+                    'action': action,
                     'object': object,
                     'user_guid': userUUID,
                     'object_id': objectID,
@@ -187,7 +186,13 @@ get_header(); ?>
                 };
 
                 // Send the event to an AJAX URL to be saved
-                jQuery.post('/wp-admin/admin-ajax.php', data);
+                jQuery.ajax({
+                    url: apiUrl + '/analytics',
+                    method: 'POST',
+                    data: JSON.stringify(data),
+                    contentType: "application/json; charset=utf-8",
+                    dataType: "json",
+                });
             }
 
             recordAnalyticsEvent('user', 'request', 'tapestry', wpPostId);
@@ -197,10 +202,7 @@ get_header(); ?>
                 document.body.addEventListener('click', function(event) {
                     var x = event.clientX + $(window).scrollLeft();
                     var y = event.clientY + $(window).scrollTop();
-                    recordAnalyticsEvent('user', 'click', 'screen', null, {
-                        'x': x,
-                        'y': y
-                    });
+                    recordAnalyticsEvent('user', 'click', 'screen', null, { x, y });
                 }, true);
 
                 document.getElementById('tapestry').addEventListener('click', function(event) {

--- a/templates/single-tapestry.php
+++ b/templates/single-tapestry.php
@@ -103,6 +103,7 @@ get_header(); ?>
     <main id="main" class="post-wrap<?php if (current_user_can('edit_post', get_the_ID())) { echo ' is-editor"'; } ?>" role="main">
 
         <div id="tapestry-container"></div>
+        <div id="user-ip" style="display:none;"><?php echo $_SERVER['REMOTE_ADDR']; ?></div>
 
         <?php while (have_posts()) : the_post(); ?>
             <?php get_template_part('content', 'page'); ?>
@@ -149,6 +150,47 @@ get_header(); ?>
             var wpUserId = "<?php echo apply_filters('determine_current_user', false); ?>";
             var apiUrl = "<?php echo get_rest_url(null, 'tapestry-tool/v1'); ?>";
             var adminAjaxUrl = "<?php echo admin_url('admin-ajax.php'); ?>";
+
+            /****************************************************
+             * ANALYTICS FUNCTIONS
+             ****************************************************/
+
+            function recordAnalyticsEvent(actor, action, object, objectID, details) {
+
+                if (wpUserId && wpUserId !== "") {
+                    var userUUID = wpUserId;
+                } else {
+                    var userUUID = Cookies.get("user-uuid");
+                    if (userUUID === undefined) {
+                        userUUID = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+                            var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+                            return v.toString(16);
+                        });
+                        Cookies.set("user-uuid", userUUID);
+                    }
+                }
+
+                if (details === undefined) {
+                    details = {};
+                }
+
+                details['user-ip'] = $('#user-ip').text();
+
+                var data = {
+                    'action': 'tapestry_log_analytics_event',
+                    'actor': actor,
+                    'action2': action,
+                    'object': object,
+                    'user_guid': userUUID,
+                    'object_id': objectID,
+                    'details': JSON.stringify(details),
+                };
+
+                // Send the event to an AJAX URL to be saved
+                jQuery.post('/wp-admin/admin-ajax.php', data);
+            }
+
+            recordAnalyticsEvent('user', 'request', 'tapestry', wpPostId);
 
             // Capture click events anywhere inside or outside tapestry
             $(document).ready(function() {

--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -326,7 +326,7 @@ function tapestryTool(config){
         
             // Attach the link line to the tapestry SVG (it won't appear for now)
             $("#" + TAPESTRY_CONTAINER_ID + " > svg").prepend(nodeLinkLine);
-            recordAnalyticsEvent('app', 'load', 'tapestry', tapestrySlug);
+            recordAnalyticsEvent('app', 'load', 'tapestry', config.wpPostId);
         }
 
         if(config.wpCanEditTapestry || tapestry.dataset.settings.nodeDraggable !== false) {
@@ -2900,55 +2900,6 @@ function screenToSVG(screenX, screenY) {
     return p.matrixTransform(svg.getScreenCTM().inverse());
 }
 
-/****************************************************
- * ANALYTICS FUNCTIONS
- ****************************************************/
-
-var analyticsAJAXUrl = '',  // e.g. '/wp-admin/admin-ajax.php' (set to empty string to disable analytics)
-    analyticsAJAXAction = 'tapestry_tool_log_event';// Analytics
-
-function recordAnalyticsEvent(actor, action, object, objectID, details){
-
-    if (!analyticsAJAXUrl.length || !analyticsAJAXAction.length)
-        return false;
-
-    // TODO: Also need to save the tapestry slug or ID in the events
-
-    var userUUID = Cookies.get("user-uuid");
-    if (userUUID === undefined) {
-        userUUID = createUUID();
-        Cookies.set("user-uuid", userUUID);
-    }
-
-    if (details === undefined) {
-        details = {};
-    }
-
-    details['user-ip'] = $('#user-ip').text();
-
-    var data = {
-        'action': analyticsAJAXAction,
-        'actor': actor,
-        'action2': action,
-        'object': object,
-        'user_guid': userUUID,
-        'object_id': objectID,
-        'details': JSON.stringify(details),
-    };
-
-    // Send the event to an AJAX URL to be saved
-    jQuery.post(analyticsAJAXUrl, data, function(response) {
-        // Event posted
-    });
-}
-
-function createUUID() {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-        var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
-        return v.toString(16);
-    });
-}
-
 function isEmptyObject(obj) {
     for(var key in obj) {
         if(obj.hasOwnProperty(key))
@@ -2956,18 +2907,3 @@ function isEmptyObject(obj) {
     }
     return true;
 }
-
-// Capture click events anywhere inside or outside tapestry
-$(document).ready(function(){
-    document.body.addEventListener('click', function(event) {
-        var x = event.clientX + $(window).scrollLeft();
-        var y = event.clientY + $(window).scrollTop();
-        recordAnalyticsEvent('user', 'click', 'screen', null, {'x': x, 'y': y});
-    }, true);
-
-    document.getElementById('tapestry').addEventListener('click', function(event) {
-        var x = event.clientX + $(window).scrollLeft();
-        var y = event.clientY + $(window).scrollTop();
-        recordAnalyticsEvent('user', 'click', 'tapestry', null, {'x': x, 'y': y});
-    }, true);
-});

--- a/templates/vue/.eslintrc.js
+++ b/templates/vue/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
     wpPostId: "readonly",
     apiUrl: "readonly",
     thisTapestryTool: "readonly",
+    globals: "readonly",
   },
   env: {
     jquery: true,

--- a/templates/vue/src/components/AudioRecorder.vue
+++ b/templates/vue/src/components/AudioRecorder.vue
@@ -41,11 +41,7 @@
       <i class="fas fa-check"></i>
       Done
     </button>
-    <button
-      v-if="state === states.DONE"
-      class="my-3"
-      @click="$emit('submit', audio)"
-    >
+    <button v-if="state === states.DONE" class="my-3" @click="handleSubmit">
       <i class="fas fa-check"></i>
       Submit
     </button>
@@ -175,25 +171,30 @@ export default {
       clearInterval(this.durationInterval)
     },
     startRecording() {
+      globals.recordAnalyticsEvent("user", "start", "audio-recorder", this.id)
       this.recorder.start()
       this.startDurationCount()
       this.state = this.states.RECORDING
     },
     pauseRecording() {
+      globals.recordAnalyticsEvent("user", "pause", "audio-recorder", this.id)
       this.recorder.pause()
       this.stopDurationCount()
       this.state = this.states.PAUSED
     },
     resumeRecording() {
+      globals.recordAnalyticsEvent("user", "resume", "audio-recorder", this.id)
       this.recorder.resume()
       this.startDurationCount()
       this.state = this.states.RECORDING
     },
     stopRecording() {
+      globals.recordAnalyticsEvent("user", "stop", "audio-recorder", this.id)
       this.recorder.stop()
       this.stopDurationCount()
     },
     resetRecording() {
+      globals.recordAnalyticsEvent("user", "reset", "audio-recorder", this.id)
       this.initialize()
       this.state = null
     },
@@ -209,6 +210,10 @@ export default {
           this.startRecording()
           break
       }
+    },
+    handleSubmit() {
+      globals.recordAnalyticsEvent("user", "submit", "audio-recorder", this.id)
+      this.$emit("submit", this.audio)
     },
   },
 }

--- a/templates/vue/src/components/Lightbox.vue
+++ b/templates/vue/src/components/Lightbox.vue
@@ -9,12 +9,12 @@
     :node-id="nodeId"
     :content-container-style="lightboxContentStyles"
     :allow-close="canSkip"
-    @close="close"
+    @close="handleUserClose"
   >
     <accordion-media
       v-if="node.mediaType === 'accordion'"
       :node="node"
-      @close="close"
+      @close="handleAutoClose"
       @complete="complete"
     />
     <tapestry-media
@@ -22,7 +22,7 @@
       :node-id="nodeId"
       :dimensions="dimensions"
       @load="handleLoad"
-      @close="close"
+      @close="handleAutoClose"
       @complete="complete"
     />
   </tapestry-modal>
@@ -186,6 +186,14 @@ export default {
           this.updateTydeProgress({ parentId: sid, isParentModule: false })
         )
       }
+    },
+    handleUserClose() {
+      globals.recordAnalyticsEvent("user", "close", "lightbox", this.nodeId)
+      this.close()
+    },
+    handleAutoClose() {
+      globals.recordAnalyticsEvent("app", "close", "lightbox", this.nodeId)
+      this.close()
     },
     close() {
       this.$router.go(-1)

--- a/templates/vue/src/components/Tyde.vue
+++ b/templates/vue/src/components/Tyde.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="tyde">
     <tapestry />
-    <tyde-module v-if="showModule" :node-id="moduleId" @done="showModule = false" />
+    <tyde-module v-if="showModule" :node-id="moduleId" @done="closeModule" />
     <tyde-spaceship @return-to-map="showModule = false" />
   </div>
 </template>
@@ -30,6 +30,12 @@ export default {
       this.moduleId = evt.detail
       this.$store.commit("updateSelectedModule", this.moduleId)
     })
+  },
+  methods: {
+    closeModule() {
+      globals.recordAnalyticsEvent("app", "close", "module", this.moduleId)
+      this.showModule = false
+    },
   },
 }
 </script>

--- a/templates/vue/src/components/lightbox/AccordionMedia.vue
+++ b/templates/vue/src/components/lightbox/AccordionMedia.vue
@@ -88,7 +88,7 @@
       :allow-close="false"
       :show-fav="false"
       :content-container-style="confirmationStyles"
-      @close="showCompletion = false"
+      @close="handleCancel"
     >
       <tyde-progress-bar
         v-if="moduleOpened"
@@ -96,10 +96,10 @@
         :node-id="this.selectedModuleId"
       />
       <div class="button-container">
-        <button class="button-completion" @click="$emit('close')">
+        <button class="button-completion" @click="handleClose">
           {{ node.typeData.continueButtonText }}
         </button>
-        <button class="button-completion" @click="showCompletion = false">
+        <button class="button-completion" @click="handleCancel">
           {{ node.typeData.cancelLinkText }}
         </button>
       </div>
@@ -216,8 +216,14 @@ export default {
     handleLoad(el) {
       this.$nextTick(() => {
         if (this.activeIndex < 0) {
+          globals.recordAnalyticsEvent("app", "scroll", "accordion", this.node.id, {
+            to: 0,
+          })
           this.$refs.container.scrollTop = 0
         } else {
+          globals.recordAnalyticsEvent("app", "scroll", "accordion", this.node.id, {
+            to: el.offsetTop - 12,
+          })
           this.$refs.container.scrollTop = el.offsetTop - 12
         }
       })
@@ -225,22 +231,61 @@ export default {
     scrollToTop() {
       const el = this.$refs.container
       if (el) {
+        globals.recordAnalyticsEvent("app", "scroll", "accordion", this.node.id, {
+          to: 0,
+        })
         el.scrollTop = 0
       }
     },
     toggle(index) {
       if (this.activeIndex === index) {
+        const activeRowId = this.rows[this.activeIndex].node.id
         this.activeIndex = -1
+        globals.recordAnalyticsEvent("user", "close", "accordion-row", activeRowId, {
+          accordion: this.node.id,
+        })
       } else {
         this.activeIndex = index
+        const activeRowId = this.rows[this.activeIndex].node.id
+        globals.recordAnalyticsEvent("user", "open", "accordion-row", activeRowId, {
+          accordion: this.node.id,
+        })
       }
     },
-    next() {
+    next(evt) {
+      globals.recordAnalyticsEvent("user", "next", "accordion", this.node.id, {
+        x: evt.clientX,
+        y: evt.clientY,
+      })
       if (this.hasNext) {
         this.activeIndex++
+        const activeRowId = this.rows[this.activeIndex].node.id
+        globals.recordAnalyticsEvent("user", "open", "accordion-row", activeRowId, {
+          accordion: this.node.id,
+        })
       } else {
         this.showCompletion = true
       }
+    },
+    handleClose(evt) {
+      globals.recordAnalyticsEvent("user", "close", "accordion", this.node.id, {
+        x: evt.clientX,
+        y: evt.clientY,
+      })
+      this.$emit("close")
+    },
+    handleCancel(evt) {
+      globals.recordAnalyticsEvent(
+        "user",
+        "close",
+        "accordion-completion-screen",
+        this.node.id,
+        {
+          x: evt.clientX,
+          y: evt.clientY,
+        }
+      )
+      this.showCompletion = false
     },
     disableRow(index) {
       if (this.node.userType === "teen") {

--- a/templates/vue/src/components/lightbox/EndScreen.vue
+++ b/templates/vue/src/components/lightbox/EndScreen.vue
@@ -11,19 +11,19 @@
       <button
         v-if="showQuizButton"
         class="end-screen-button button-quiz"
-        @click="$emit('show-quiz')"
+        @click="handleClick($event, 'show-quiz')"
       >
         <i class="fas fa-question-circle"></i>
         <p class="end-screen-button-text">{{ buttonText }}</p>
       </button>
-      <button class="end-screen-button" @click="$emit('rewatch')">
+      <button class="end-screen-button" @click="handleClick($event, 'rewatch')">
         <i class="fas fa-play"></i>
         <p class="end-screen-button-text">Replay Video</p>
       </button>
       <button
         v-if="!showQuizButton"
         class="end-screen-button"
-        @click="$emit('close')"
+        @click="handleClick($event, 'close')"
       >
         <i class="fas fa-arrow-circle-right"></i>
         <p class="end-screen-button-text">Continue</p>
@@ -31,7 +31,7 @@
       <button
         v-if="showQuizButton"
         class="end-screen-button"
-        @click="$emit('close')"
+        @click="handleClick($event, 'close')"
       >
         <i class="fas fa-history"></i>
         <p class="end-screen-button-text">Come Back Later</p>
@@ -69,6 +69,15 @@ export default {
     },
     backgroundUrl() {
       return `url(${wpData.vue_uri}/${EndScreenBg.split("dist")[1]})`
+    },
+  },
+  methods: {
+    handleClick(evt, type) {
+      globals.recordAnalyticsEvent("user", "click", "end-screen", this.node.id, {
+        x: evt.clientX,
+        y: evt.clientY,
+      })
+      this.$emit(type)
     },
   },
 }

--- a/templates/vue/src/components/lightbox/GravityForm.vue
+++ b/templates/vue/src/components/lightbox/GravityForm.vue
@@ -57,6 +57,7 @@ export default {
 
     this.disableAutocomplete()
     this.styleImageUI()
+    this.addInputListeners()
 
     if (this.entry) {
       this.populateForm()
@@ -122,6 +123,7 @@ export default {
             delete window[`gf_submitting_${this.id}`]
             this.html = response.data
           } else {
+            globals.recordAnalyticsEvent("user", "submit", "gf", this.id)
             this.$emit("submit")
           }
         })

--- a/templates/vue/src/components/lightbox/GravityForm.vue
+++ b/templates/vue/src/components/lightbox/GravityForm.vue
@@ -68,6 +68,40 @@ export default {
     }
   },
   methods: {
+    addInputListeners() {
+      const form = this.$refs.formContainer.querySelector("form")
+
+      const textareas = form.querySelectorAll("textarea")
+      textareas.forEach(textarea => {
+        const events = ["focus", "blur"]
+        events.forEach(event =>
+          textarea.addEventListener(event, () =>
+            globals.recordAnalyticsEvent("user", event, "gf-textarea", this.id)
+          )
+        )
+      })
+
+      const inputs = form.querySelectorAll("input")
+      inputs.forEach(input => {
+        if (input.type === "text") {
+          const events = ["focus", "blur"]
+          events.forEach(event =>
+            input.addEventListener(event, () =>
+              globals.recordAnalyticsEvent("user", event, "gf-input", this.id)
+            )
+          )
+        } else {
+          input.addEventListener("input", () => {
+            globals.recordAnalyticsEvent(
+              "user",
+              "input",
+              `gf-${input.type}`,
+              this.id
+            )
+          })
+        }
+      })
+    },
     handleSubmit(event) {
       // stop the original form event
       event.preventDefault()

--- a/templates/vue/src/components/lightbox/H5PIframe.vue
+++ b/templates/vue/src/components/lightbox/H5PIframe.vue
@@ -74,6 +74,7 @@ export default {
       if (h5pVideo) {
         this.played = true
         h5pVideo.play()
+        this.handlePlay(this.node)
       }
     },
     rewatch() {
@@ -81,6 +82,7 @@ export default {
       const h5pVideo = h5pObj.instances[0].video
       h5pVideo.seek(0)
       h5pVideo.play()
+      this.handlePlay(this.node)
     },
     close() {
       const h5pObj = this.$refs.h5p.contentWindow.H5P
@@ -153,7 +155,7 @@ export default {
       this.$emit("show-play-screen", false)
       const { id, mediaType } = node
       thisTapestryTool.updateMediaIcon(id, mediaType, "pause")
-      thisTapestryTool.recordAnalyticsEvent("user", "play", "h5p-video", id, {
+      globals.recordAnalyticsEvent("user", "play", "h5p-video", id, {
         time: node.typeData.progress[0].value * node.mediaDuration,
       })
     },
@@ -161,7 +163,7 @@ export default {
       this.$emit("show-play-screen", true)
       const { id, mediaType } = node
       thisTapestryTool.updateMediaIcon(id, mediaType, "play")
-      thisTapestryTool.recordAnalyticsEvent("user", "pause", "h5p-video", id, {
+      globals.recordAnalyticsEvent("user", "pause", "h5p-video", id, {
         time: node.typeData.progress[0].value * node.mediaDuration,
       })
     },

--- a/templates/vue/src/components/lightbox/H5PMedia.vue
+++ b/templates/vue/src/components/lightbox/H5PMedia.vue
@@ -26,7 +26,7 @@
       @timeupdate="$emit('timeupdate', $event)"
       @show-end-screen="showEndScreen = allowEndScreen"
       @show-play-screen="showPlayScreen = $event"
-      @update-settings="updateH5pSettings"
+      @update-settings="updateSettings"
     />
   </div>
 </template>
@@ -104,6 +104,16 @@ export default {
     handleLoad() {
       this.isLoading = false
       this.$emit("load")
+    },
+    updateSettings(settings) {
+      globals.recordAnalyticsEvent(
+        "user",
+        "update-settings",
+        "h5p-video",
+        this.node.id,
+        { from: this.h5pSettings, to: settings }
+      )
+      this.updateH5pSettings(settings)
     },
   },
 }

--- a/templates/vue/src/components/lightbox/QuizScreen.vue
+++ b/templates/vue/src/components/lightbox/QuizScreen.vue
@@ -5,7 +5,7 @@
         <i class="fas fa-arrow-circle-right fa-4x"></i>
         <p>Next question</p>
       </button>
-      <button v-else class="button-completion" @click="$emit('close')">
+      <button v-else class="button-completion" @click="close">
         <i class="far fa-times-circle fa-4x"></i>
         <p>Done</p>
       </button>
@@ -86,11 +86,23 @@ export default {
     },
     next() {
       this.showCompletionScreen = false
+      globals.recordAnalyticsEvent("user", "next", "activity", this.node.id, {
+        from: this.activeQuestionIndex,
+        to: this.activeQuestionIndex + 1,
+      })
       this.activeQuestionIndex++
     },
     prev() {
       this.showCompletionScreen = false
+      globals.recordAnalyticsEvent("user", "prev", "activity", this.node.id, {
+        from: this.activeQuestionIndex,
+        to: this.activeQuestionIndex - 1,
+      })
       this.activeQuestionIndex--
+    },
+    close() {
+      globals.recordAnalyticsEvent("user", "close", "activity", this.node.id)
+      this.$emit("close")
     },
   },
 }

--- a/templates/vue/src/components/lightbox/VideoMedia.vue
+++ b/templates/vue/src/components/lightbox/VideoMedia.vue
@@ -120,6 +120,9 @@ export default {
     },
     play() {
       if (this.$refs.video) {
+        globals.recordAnalyticsEvent("app", "play", "video", this.node.id, {
+          time: this.$refs.video.currentTime,
+        })
         this.$refs.video.play()
       }
     },
@@ -128,6 +131,9 @@ export default {
       this.showEndScreen = false
       if (this.$refs.video) {
         this.$refs.video.currentTime = 0
+        globals.recordAnalyticsEvent("app", "play", "video", this.node.id, {
+          time: 0,
+        })
         this.$refs.video.play()
       }
     },
@@ -138,6 +144,9 @@ export default {
     close() {
       if (this.$refs.video) {
         this.$refs.video.pause()
+        globals.recordAnalyticsEvent("app", "pause", "video", this.node.id, {
+          time: this.$refs.video.currentTime,
+        })
         this.updateVideoProgress()
       }
       this.$emit("close")
@@ -160,7 +169,7 @@ export default {
       thisTapestryTool.updateMediaIcon(id, mediaType, "pause")
       const video = this.$refs.video
       if (video) {
-        thisTapestryTool.recordAnalyticsEvent("user", "play", "html5-video", id, {
+        globals.recordAnalyticsEvent("user", "play", "video", id, {
           time: video.currentTime,
         })
       }
@@ -171,7 +180,7 @@ export default {
       thisTapestryTool.updateMediaIcon(id, mediaType, "play")
       const video = this.$refs.video
       if (video) {
-        thisTapestryTool.recordAnalyticsEvent("user", "pause", "html5-video", id, {
+        globals.recordAnalyticsEvent("user", "pause", "video", id, {
           time: video.currentTime,
         })
       }

--- a/templates/vue/src/components/lightbox/VideoMedia.vue
+++ b/templates/vue/src/components/lightbox/VideoMedia.vue
@@ -1,5 +1,10 @@
 <template>
-  <div :class="['video-container', { fullscreen: node.fullscreen, 'allow-scroll': showQuizScreen }]">
+  <div
+    :class="[
+      'video-container',
+      { fullscreen: node.fullscreen, 'allow-scroll': showQuizScreen },
+    ]"
+  >
     <play-screen v-if="showPlayScreen" @play="play" />
     <end-screen
       v-if="showEndScreen"

--- a/templates/vue/src/components/lightbox/quiz-screen/CompletionScreen.vue
+++ b/templates/vue/src/components/lightbox/quiz-screen/CompletionScreen.vue
@@ -24,7 +24,7 @@ export default {
   props: {
     question: {
       type: Object,
-      required: false,
+      required: true,
     },
   },
 }

--- a/templates/vue/src/components/lightbox/quiz-screen/Question.vue
+++ b/templates/vue/src/components/lightbox/quiz-screen/Question.vue
@@ -162,6 +162,7 @@ export default {
   methods: {
     ...mapActions(["completeQuestion", "saveAudio"]),
     back() {
+      globals.recordAnalyticsEvent("user", "back", "question", this.question.id)
       const wasOpened = this.formOpened || this.recorderOpened
       if (!wasOpened || this.options.length === 1) {
         this.$emit("back")
@@ -170,9 +171,28 @@ export default {
       this.recorderOpened = false
     },
     openRecorder() {
+      globals.recordAnalyticsEvent(
+        "user",
+        "click",
+        "answer-button",
+        this.question.id,
+        {
+          type: "audio-recorder",
+        }
+      )
       this.recorderOpened = true
     },
     openForm(id, answerType) {
+      globals.recordAnalyticsEvent(
+        "user",
+        "click",
+        "answer-button",
+        this.question.id,
+        {
+          type: answerType,
+          id,
+        }
+      )
       this.formId = id
       this.formType = answerType
       this.formOpened = true
@@ -188,6 +208,13 @@ export default {
           questionId: this.question.id,
         })
         this.loading = false
+        globals.recordAnalyticsEvent(
+          "user",
+          "submit",
+          "question",
+          this.question.id,
+          { type: this.formType, id: this.formId }
+        )
         this.$emit("submit")
       }
     },
@@ -206,6 +233,9 @@ export default {
         questionId: this.question.id,
       })
       this.loading = false
+      globals.recordAnalyticsEvent("user", "submit", "question", this.question.id, {
+        type: "audio",
+      })
       this.$emit("submit")
     },
     hasId(label) {

--- a/templates/vue/src/components/lightbox/quiz-screen/Question.vue
+++ b/templates/vue/src/components/lightbox/quiz-screen/Question.vue
@@ -258,7 +258,7 @@ button {
       max-width: 100px;
     }
   }
-  
+
   h3 {
     font-size: 2em;
   }

--- a/templates/vue/src/components/tyde/TydeButton.vue
+++ b/templates/vue/src/components/tyde/TydeButton.vue
@@ -2,7 +2,7 @@
   <button
     :class="['tyde-button', { 'has-label': label.length > 0 }]"
     :style="cssProps"
-    @click="$emit('click')"
+    @click="$emit('click', $event)"
   >
     <i v-if="icon.length" :class="iconClass"></i>
     <slot></slot>

--- a/templates/vue/src/components/tyde/TydeModule.vue
+++ b/templates/vue/src/components/tyde/TydeModule.vue
@@ -48,12 +48,15 @@ export default {
   watch: {
     activeStage(newStage) {
       if (this.isLightboxOpen) {
+        globals.recordAnalyticsEvent("app", "close", "lightbox", newStage)
         this.closeLightbox()
       }
+      globals.recordAnalyticsEvent("app", "open", "lightbox", newStage)
       this.openLightbox(newStage)
     },
   },
   mounted() {
+    globals.recordAnalyticsEvent("app", "open", "lightbox", this.activeStage)
     this.openLightbox(this.activeStage)
   },
   methods: {
@@ -67,7 +70,12 @@ export default {
     next() {
       if (this.activeStageIndex < this.stages.length - 1) {
         this.activeStageIndex++
+        globals.recordAnalyticsEvent("app", "next", "stage", this.nodeId, {
+          from: this.activeStageIndex - 1,
+          to: this.activeStageIndex,
+        })
       } else {
+        globals.recordAnalyticsEvent("app", "open", "lightbox", this.nodeId)
         this.openLightbox(this.nodeId)
         this.$emit("done")
       }
@@ -75,6 +83,10 @@ export default {
     prev() {
       if (this.activeStageIndex > 0) {
         this.activeStageIndex--
+        globals.recordAnalyticsEvent("app", "prev", "stage", this.nodeId, {
+          from: this.activeStageIndex + 1,
+          to: this.activeStageIndex,
+        })
       }
     },
   },

--- a/templates/vue/src/components/tyde/TydeStage.vue
+++ b/templates/vue/src/components/tyde/TydeStage.vue
@@ -199,19 +199,11 @@ body.tapestry-stage-open {
     h1 {
       font-family: inherit;
       font-size: 3.2em;
-      text-shadow: 0px 0px 1px #1C0544,
-                  1px 1px 1px #1C0544,
-                  1px -1px 1px #1C0544,
-                  -1px 1px 1px #1C0544,
-                  -1px -1px 1px #1C0544,
-                  2px 1px 1px #1C0544,
-                  2px -1px 1px #1C0544,
-                  -2px 1px 1px #1C0544,
-                  -2px -2px 1px #1C0544,
-                  1px 2px 1px #1C0544,
-                  1px -2px 1px #1C0544,
-                  -1px 2px 1px #1C0544,
-                  2px 2px 1px #1C0544;
+      text-shadow: 0px 0px 1px #1c0544, 1px 1px 1px #1c0544, 1px -1px 1px #1c0544,
+        -1px 1px 1px #1c0544, -1px -1px 1px #1c0544, 2px 1px 1px #1c0544,
+        2px -1px 1px #1c0544, -2px 1px 1px #1c0544, -2px -2px 1px #1c0544,
+        1px 2px 1px #1c0544, 1px -2px 1px #1c0544, -1px 2px 1px #1c0544,
+        2px 2px 1px #1c0544;
 
       &::before {
         display: none;

--- a/templates/vue/src/components/tyde/TydeStage.vue
+++ b/templates/vue/src/components/tyde/TydeStage.vue
@@ -11,7 +11,7 @@
         <tyde-button
           class="close-button"
           icon="times"
-          @click="$emit('close')"
+          @click="handleClick($event, 'close')"
         ></tyde-button>
       </div>
       <section>
@@ -22,19 +22,19 @@
           :topic="topic"
           :show-complete="true"
           style="align-self: flex-start;"
-          @click="openLightbox(topic.id)"
+          @click="openTopic($event, topic.id)"
         />
       </section>
       <footer>
         <tyde-button
           :disabled="!stageIndex"
           label="Prev"
-          @click="$emit(stageIndex ? 'prev' : '')"
+          @click="handleClick($event, 'prev')"
         ></tyde-button>
         <tyde-button
           :disabled="!done"
           label="Next"
-          @click="$emit(done ? 'next' : '')"
+          @click="handleClick($event, 'next')"
         ></tyde-button>
       </footer>
     </div>
@@ -142,11 +142,23 @@ export default {
       }
       return {}
     },
+    openTopic(evt, id) {
+      globals.recordAnalyticsEvent("user", "click", "topic", id, {
+        x: evt.clientX,
+        y: evt.clientY,
+      })
+      this.openLightbox(id)
+    },
     openLightbox(id) {
+      globals.recordAnalyticsEvent("user", "open", "topic", id)
       this.$router.push(`/nodes/${id}`)
     },
-    closeLightbox() {
-      this.$router.push(`/`)
+    handleClick(evt, type) {
+      globals.recordAnalyticsEvent("user", "click", `stage-${type}-button`, null, {
+        x: evt.clientX,
+        y: evt.clientY,
+      })
+      this.$emit(type)
     },
   },
 }

--- a/templates/vue/src/components/tyde/TydeTopic.vue
+++ b/templates/vue/src/components/tyde/TydeTopic.vue
@@ -1,5 +1,5 @@
 <template>
-  <button @click="$emit('click')">
+  <button @click="$emit('click', $event)">
     <div>
       <img :src="topic.imageURL" />
       <i v-if="topic.completed && showComplete" class="fas fa-check fa-3x"></i>

--- a/templates/vue/src/components/tyde/TydeTopic.vue
+++ b/templates/vue/src/components/tyde/TydeTopic.vue
@@ -70,11 +70,8 @@ button {
     line-height: 1.3em;
     max-width: 200px;
     min-height: 2em;
-    text-shadow: 0px 0px 1px #1C0544,
-              1px 1px 1px #1C0544,
-              1px -1px 1px #1C0544,
-              -1px 1px 1px #1C0544,
-              -1px -1px 1px #1C0544;
+    text-shadow: 0px 0px 1px #1c0544, 1px 1px 1px #1c0544, 1px -1px 1px #1c0544,
+      -1px 1px 1px #1c0544, -1px -1px 1px #1c0544;
   }
 }
 </style>


### PR DESCRIPTION
- Create table for saving events upon plugin activation
- Add admin-ajax endpoint for saving analytics events
- Make necessary updates to make basic analytics work

List of events to save analytics for:

- Lightbox
  - [x] Opened via media button U
  - [x] Opened via module ending A
  - [x] Opened via stage initialization A
  - [x] Opened via topic selection A
  - [x] Closed via close button U
  - [x] Closed via all other means A
- Depth slider
  - [x] Changed U
- Modules
  - [x] Start U
  - [x] Closed A
- Stages
  - [x] Next button pressed U
  - [x] Finish button pressed U
- Topics
  - [x] Topic button pressed U
- Nodes
  - [x] Clicked U
  - Videos/H5P Videos
    - [x] Autoplay/play/pause A
    - [x] Play/paused U
    - [x] Settings change U
    - [x] End screen buttons pressed U
  - Activity
    - [x] Answer button pressed U
    - [x] Next/previous question pressed U
  - Gravity form
    - [x] Text input or textarea focused/blurred U
    - [x] Radio button or checklist checked/unchecked U
    - [x] Form submitted U
 - Audio recorder
    - [x] Record/pause/done buttons pressed U
  - Accordion/sub accordion
    - [x] Finish button pressed U
    - [x] Accordion row pressed U
    - [x] Accordion row opened via finish button A
    - [x] Scroll content to view A