### PR TITLE
Fix H5P Modal Switching and Infinite H5P Load

### DIFF
--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -600,6 +600,12 @@ export default {
     },
     handleTypeChange(event) {
       this.$set(this.node, "mediaType", event)
+      if (event === "video" || event === "h5p") {
+        this.$set(this.node, "mediaFormat", event === "video" ? "mp4" : "h5p")
+      } else {
+        this.$set(this.node, "mediaFormat", "")
+      }
+      this.videoSrc = ""
     },
     submitNode() {
       this.formErrors = this.validateNode(this.nodeData)

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -686,6 +686,10 @@ export default {
       // Set media duration if video is loaded
       const h5pFrame = this.$refs.h5pNone.contentWindow.H5P
       const h5pVideo = h5pFrame.instances[0].video
+      if (!h5pVideo) {
+        this.videoLoaded = true
+        return
+      }
       const handleH5PLoad = () => {
         this.node.mediaDuration = h5pVideo.getDuration()
         this.videoLoaded = true


### PR DESCRIPTION
Closes #569 
MediaType and Format were being set during submission, not dynamically. 

Steps to test:
1. Create an H5P node with video content, submit
2. Edit that node and switch to video type
3. Verify correct form appears
4. Add Video URL and submit node
5. Edit again, and switch back to H5P type
6. Submit button should be accessible 
7. Add a non-video H5P content and verify the submit button is still accessible after a brief delay