### PR TITLE
[No Ticket] Fix bugs revolving around two Tapestry instances

### DIFF
--- a/tapestry.php
+++ b/tapestry.php
@@ -137,12 +137,15 @@ function tapestry_enqueue_tapestry_js()
 		wp_enqueue_script('wp_tapestry_script');
 
 		wp_add_inline_script( 'wp_tapestry_script', "
-			var thisTapestryTool = new tapestryTool({
-				'containerId': 'tapestry',
-				'apiUrl': '". get_rest_url(null, 'tapestry-tool/v1') ."',
-				'wpUserId': '". apply_filters('determine_current_user', false) ."',
-				'wpPostId': '". get_the_ID() ."',
-				'wpCanEditTapestry': '". current_user_can('edit_post', get_the_ID()) ."',
+			var thisTapestryTool;
+			$(document).ready(function() {
+				thisTapestryTool = new tapestryTool({
+					'containerId': 'tapestry',
+					'apiUrl': '". get_rest_url(null, 'tapestry-tool/v1') ."',
+					'wpUserId': '". apply_filters('determine_current_user', false) ."',
+					'wpPostId': '". get_the_ID() ."',
+					'wpCanEditTapestry': '". current_user_can('edit_post', get_the_ID()) ."',
+				});
 			});
 		" );
 	}

--- a/templates/single-tapestry.php
+++ b/templates/single-tapestry.php
@@ -11,20 +11,6 @@ Template Name: Tapestry Page Template
 
 get_header();
 
-wp_add_inline_script( 'wp_tapestry_script', "
-    var thisTapestryTool;
-    $(document).ready(function(){
-        thisTapestryTool = new tapestryTool({
-            'containerId': 'tapestry',
-            'apiUrl': '". get_rest_url(null, 'tapestry-tool/v1') ."',
-            'wpUserId': '". apply_filters('determine_current_user', false) ."',
-            'wpPostId': '". get_the_ID() ."',
-            'wpCanEditTapestry': '". current_user_can('edit_post', get_the_ID()) ."',
-            'addNodeModalUrl': '". plugin_dir_url( __FILE__ ) ."modal-add-node.html',
-        });
-    });
-");
-
 if (current_user_can('edit_post', get_the_ID())) { 
     $additionalClasses = 'is-editor"';
 }


### PR DESCRIPTION
Fixes two critical bugs that were caused by there being two Tapestry instances loaded at the same time:

- Lightbox opening when edit node is clicked
- Node titles disappearing after lightbox is open