### PR TITLE
617 - Bug fix: Tapestry doesn't load if some nodes for associated links have been deleted

### DIFF
--- a/templates/tapestry.js
+++ b/templates/tapestry.js
@@ -134,6 +134,7 @@ function tapestryTool(config){
             yORfy = autoLayout ? 'y' : 'fy';
         }
 
+		var nodeIds = [];
         for (var i=0; i < tapestry.dataset.nodes.length; i++) {
             if (autoLayout) {
                 delete tapestry.dataset.nodes[i].fx;
@@ -143,7 +144,12 @@ function tapestryTool(config){
                 tapestry.dataset.nodes[i].fx = tapestry.dataset.nodes[i].coordinates.x;
                 tapestry.dataset.nodes[i].fy = tapestry.dataset.nodes[i].coordinates.y;
             }
+			nodeIds.push(tapestry.dataset.nodes[i].id);
         }
+
+		// Delete links that connect to a non-existing node due to possibly corrupted data
+		tapestry.dataset.links = tapestry.dataset.links.filter(
+            thisLink => nodeIds.includes(thisLink.source) && nodeIds.includes(thisLink.target));
 
         tapestry.originalDataset = tapestry.dataset;
         
@@ -2303,6 +2309,11 @@ function tapestryTool(config){
                 if (node.mediaType !== "accordion" && tapestry.dataset.nodes[index].typeData.progress) {
                     //Update the dataset with new values
 
+                    // Error prevention
+					if (!node.typeData.progress) {
+						node.typeData.progress = [ {'value': 0}, {'value': 1 } ];
+                    }
+                    
                     node.typeData.progress[0].value = amountViewed;
                     node.typeData.progress[1].value = amountUnviewed;
 

--- a/templates/vue/src/components/Tapestry.vue
+++ b/templates/vue/src/components/Tapestry.vue
@@ -1,10 +1,6 @@
 <template>
   <div id="tapestry">
-    <loading
-      v-if="!tapestryLoaded"
-      style="padding: 30vh 0;"
-      label="Loading"
-    />
+    <loading v-if="!tapestryLoaded" style="padding: 30vh 0;" label="Loading" />
     <settings-modal :wp-can-edit-tapestry="wpCanEditTapestry" />
     <div v-if="tapestryLoaded && !tapestry.rootId">
       <root-node-button v-if="wpCanEditTapestry" @click="addRootNode" />


### PR DESCRIPTION
This fix makes tapestry more resilient by removing links that shouldn't be there when the tapestry loads on the frontend. These are links that exist that point to nodes that have been deleted.

This doesn't deal with the underlying problem that is causing nodes to get deleted without their associated links getting deleted. That needs to be addressed still.