### PR TITLE
628 - Enable hiding nodes from Admin and implement Author filter in backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 package-lock.json
+.php_cs.cache
 .DS_Store
 docker/wp-config.php

--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -288,6 +288,17 @@ class Tapestry implements ITapestry
         );
     }
 
+    public function getAllContributors()
+    {
+        return array_unique(array_map(
+            function ($node) {
+                $node = new TapestryNode($this->postId, $node);
+                return $node->get()->author;
+            },
+            $this->nodes
+        ), SORT_REGULAR);
+    }
+
     private function _setAccessibleStatus($nodes, $userId)
     {
         $newNodes = array_map(

--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -381,7 +381,7 @@ class Tapestry implements ITapestry
         $tapestry->settings->nodeDraggable = true;
         $tapestry->settings->showAccess = true;
         $tapestry->settings->defaultPermissions = TapestryNodePermissions::getDefaultNodePermissions($this->postId);
-        $tapestry->settings->superuserOverridePermissions = false;
+        $tapestry->settings->superuserOverridePermissions = true;
 
         return $tapestry;
     }

--- a/endpoints.php
+++ b/endpoints.php
@@ -280,6 +280,13 @@ $REST_API_ENDPOINTS = [
             },
         ],
     ],
+    'GET_TAPESTRY_CONTRIBUTORS' => (object) [
+        'ROUTE' => '/tapestries/contributors',
+        'ARGUMENTS' => [
+            'methods' => $REST_API_GET_METHOD,
+            'callback' => 'getTapestryContributors'
+        ],
+    ],
 ];
 
 /**
@@ -1257,6 +1264,22 @@ function updateUserFavourites($request)
     try {
         $userProgress = new TapestryUserProgress($postId);
         return $userProgress->updateFavourites($favourites);
+    } catch (TapestryError $e) {
+        return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
+    }
+}
+
+function getTapestryContributors($request)
+{
+    $postId = $request['post_id'];
+    $roles = new TapestryUserRoles();
+
+    try {
+        if (!$roles->canEdit($postId)) {
+            throw new TapestryError('TAPESTRY_PERMISSION_DENIED');
+        }
+        $tapestry = new Tapestry($postId);
+        return $tapestry->getAllContributors();
     } catch (TapestryError $e) {
         return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
     }

--- a/endpoints.php
+++ b/endpoints.php
@@ -279,7 +279,7 @@ $REST_API_ENDPOINTS = [
         ],
     ],
     'GET_TAPESTRY_CONTRIBUTORS' => (object) [
-        'ROUTE' => '/tapestries/contributors',
+        'ROUTE' => '/tapestries/(?P<tapestryPostId>[\d]+)/contributors',
         'ARGUMENTS' => [
             'methods' => $REST_API_GET_METHOD,
             'callback' => 'getTapestryContributors'
@@ -1292,7 +1292,7 @@ function updateUserFavourites($request)
 
 function getTapestryContributors($request)
 {
-    $postId = $request['post_id'];
+    $postId = $request['tapestryPostId'];
     $roles = new TapestryUserRoles();
 
     try {

--- a/endpoints.php
+++ b/endpoints.php
@@ -365,9 +365,10 @@ function getGfEntry($request)
 function getTapestry($request)
 {
     $postId = $request['tapestryPostId'];
+    $filterUserId = $request['filter_user_id'];
     try {
         $tapestry = new Tapestry($postId);
-        return $tapestry->get();
+        return $tapestry->get($filterUserId);
     } catch (TapestryError $e) {
         return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
     }
@@ -514,10 +515,9 @@ function addTapestryNode($request)
         $tapestry = new Tapestry($postId);
 
         if ($tapestry->isEmpty()) {
-            if (!(TapestryUserRoles::isEditor())
-                && !(TapestryUserRoles::isAdministrator())
-                && !(TapestryUserRoles::isAuthorOfThePost($postId))
-            ) {
+            $roles = new TapestryUserRoles();
+            if (!$roles->canEdit($postId))
+            {
                 throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
             }
         }
@@ -576,10 +576,10 @@ function addTapestryLink($request)
         ) {
             throw new TapestryError('INVALID_CHILD_NODE');
         }
-        if (!TapestryHelpers::currentUserIsAllowed('ADD', $link->source, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('ADD', $link->source, $postId)) {
             throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
         }
-        if (!TapestryHelpers::currentUserIsAllowed('ADD', $link->target, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('ADD', $link->target, $postId)) {
             throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
         }
         $tapestry = new Tapestry($postId);
@@ -656,7 +656,7 @@ function updateTapestryNode($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::currentUserIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -694,7 +694,7 @@ function deleteTapestryNode($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::currentUserIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -729,7 +729,7 @@ function updateTapestryNodeSize($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::currentUserIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -767,7 +767,7 @@ function updateTapestryNodePermissions($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::currentUserIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -805,7 +805,7 @@ function updateTapestryNodeDescription($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::currentUserIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -843,7 +843,7 @@ function updateTapestryNodeTitle($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::currentUserIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -881,7 +881,7 @@ function updateTapestryNodeImageURL($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::currentUserIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -919,7 +919,7 @@ function updateTapestryNodeLockedImageURL($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::currentUserIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -956,7 +956,7 @@ function updateTapestryNodeTypeData($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::currentUserIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {
@@ -994,7 +994,7 @@ function updateTapestryNodeCoordinates($request)
         if (!TapestryHelpers::isValidTapestryNode($nodeMetaId)) {
             throw new TapestryError('INVALID_NODE_META_ID');
         }
-        if (!TapestryHelpers::currentUserIsAllowed('EDIT', $nodeMetaId, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('EDIT', $nodeMetaId, $postId)) {
             throw new TapestryError('EDIT_NODE_PERMISSION_DENIED');
         }
         if (!TapestryHelpers::isChildNodeOfTapestry($nodeMetaId, $postId)) {

--- a/endpoints.php
+++ b/endpoints.php
@@ -282,7 +282,7 @@ $REST_API_ENDPOINTS = [
         'ROUTE' => '/tapestries/(?P<tapestryPostId>[\d]+)/contributors',
         'ARGUMENTS' => [
             'methods' => $REST_API_GET_METHOD,
-            'callback' => 'getTapestryContributors'
+            'callback' => 'getTapestryContributors',
         ],
     ],
 ];
@@ -378,6 +378,7 @@ function getTapestry($request)
     $filterUserId = $request['filter_user_id'];
     try {
         $tapestry = new Tapestry($postId);
+
         return $tapestry->get($filterUserId);
     } catch (TapestryError $e) {
         return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
@@ -529,8 +530,7 @@ function addTapestryNode($request)
 
         if ($tapestry->isEmpty()) {
             $roles = new TapestryUserRoles();
-            if (!$roles->canEdit($postId))
-            {
+            if (!$roles->canEdit($postId)) {
                 throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
             }
         }
@@ -1300,6 +1300,7 @@ function getTapestryContributors($request)
             throw new TapestryError('TAPESTRY_PERMISSION_DENIED');
         }
         $tapestry = new Tapestry($postId);
+
         return $tapestry->getAllContributors();
     } catch (TapestryError $e) {
         return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());

--- a/interfaces/interface.tapestry.php
+++ b/interfaces/interface.tapestry.php
@@ -94,4 +94,11 @@ interface ITapestry
      * @return  Boolean true if there is no root node, false otherwise
      */
     public function isEmpty();
+
+    /**
+     * Returns all users who have authored a node within the tapestry
+     *
+     * @return Array Wordpress users
+     */
+    public function getAllContributors();
 }

--- a/interfaces/interface.tapestry.php
+++ b/interfaces/interface.tapestry.php
@@ -34,7 +34,7 @@ interface ITapestry
      *
      * @return  Object  $tapestry
      */
-    public function get();
+    public function get($filterUserId);
 
     /**
      * Get node IDs

--- a/interfaces/interface.tapestry.php
+++ b/interfaces/interface.tapestry.php
@@ -95,9 +95,9 @@ interface ITapestry
     public function isEmpty();
 
     /**
-     * Returns all users who have authored a node within the tapestry
+     * Returns all users who have authored a node within the tapestry.
      *
-     * @return Array Wordpress users
+     * @return array Wordpress users
      */
     public function getAllContributors();
 }

--- a/templates/vue/src/components/SettingsModal.vue
+++ b/templates/vue/src/components/SettingsModal.vue
@@ -99,6 +99,14 @@ const defaultPermissions = Object.fromEntries(
   ].map(rowName => [rowName, ["read"]])
 )
 
+const defaultSettings = {
+  backgroundUrl: "",
+  autoLayout: false,
+  nodeDraggable: true,
+  showAccess: true,
+  superuserOverridePermissions: true,
+}
+
 export default {
   name: "settings-modal",
   components: {
@@ -142,6 +150,7 @@ export default {
     openModal() {
       this.$bvModal.show("settings-modal")
       this.getSettings()
+      this.synchronizeSettings()
     },
     closeModal() {
       this.$bvModal.hide("settings-modal")
@@ -192,6 +201,14 @@ export default {
       URL.revokeObjectURL(fileUrl)
       document.body.removeChild(a)
     },
+    synchronizeSettings() {
+      const tapestrySettings = this.settings
+      for (const setting in defaultSettings) {
+        if (!tapestrySettings.hasOwnProperty(setting)) {
+          this.updateSettings()
+        }
+      }
+    }
   },
 }
 </script>

--- a/templates/vue/src/components/SettingsModal.vue
+++ b/templates/vue/src/components/SettingsModal.vue
@@ -35,6 +35,15 @@
               {{ autoLayout ? "Enabled" : "Disabled" }}
             </b-form-checkbox>
           </b-form-group>
+          <b-form-group
+            label="Superusers Override Permissions"
+            description="When this is enabled, all WordPress superusers (Administator roles, Editor roles or the
+             Author of this Tapestry) will be able to see and edit all nodes, regardless of the node's set permissions."
+          >
+            <b-form-checkbox v-model="superuserOverridePermissions" switch>
+              {{ superuserOverridePermissions ? "Enabled" : "Disabled" }}
+            </b-form-checkbox>
+          </b-form-group>
         </b-tab>
         <b-tab title="Advanced">
           <b-button block variant="light" @click="exportTapestry">
@@ -112,6 +121,7 @@ export default {
       userId: "",
       showAccess: true,
       defaultPermissions,
+      superuserOverridePermissions: true,
     }
   },
   computed: {
@@ -143,12 +153,14 @@ export default {
         nodeDraggable = true,
         defaultPermissions = this.defaultPermissions,
         showAccess = true,
+        superuserOverridePermissions = true,
       } = this.settings
       this.backgroundUrl = backgroundUrl
       this.autoLayout = autoLayout
       this.nodeDraggable = nodeDraggable
       this.defaultPermissions = defaultPermissions
       this.showAccess = showAccess
+      this.superuserOverridePermissions = superuserOverridePermissions
     },
     async updateSettings() {
       const settings = Object.assign(this.settings, {
@@ -157,6 +169,7 @@ export default {
         nodeDraggable: this.nodeDraggable,
         defaultPermissions: this.defaultPermissions,
         showAccess: this.showAccess,
+        superuserOverridePermissions: this.superuserOverridePermissions,
       })
       await this.$store.dispatch("updateSettings", settings)
       // TODO: Improve behavior so refresh is not required (currently auto-layout and setting the background image only happen initially)

--- a/templates/vue/src/components/SettingsModal.vue
+++ b/templates/vue/src/components/SettingsModal.vue
@@ -36,11 +36,11 @@
             </b-form-checkbox>
           </b-form-group>
           <b-form-group
-            label="Show Me All Nodes By Default"
-            description="If enabled, editors of this tapestry would be able to see and edit all nodes even 
-            for nodes with the 'read' permission off. If disabled, superusers will be able to use the filter 
-            to view such nodes, but they won't appear in the tapestry by default. Note: Editors of this 
-            tapestry include users with the Administator or Edit roles, and the author of this Tapestry."
+            label="Show me all nodes by default"
+            description="If enabled, editors of this tapestry would be able to view all nodes even if they have 
+            the 'read' permission off. If disabled, superusers will be able to use the filter to view such nodes, 
+            but they won't appear in the tapestry by default. Note: Editors of this tapestry include users with 
+            the Administator or Editor role, and the author of this Tapestry."
           >
             <b-form-checkbox v-model="superuserOverridePermissions" switch>
               {{ superuserOverridePermissions ? "Enabled" : "Disabled" }}
@@ -234,7 +234,7 @@ export default {
           this.updateSettings()
         }
       }
-    }
+    },
   },
 }
 </script>

--- a/templates/vue/src/components/SettingsModal.vue
+++ b/templates/vue/src/components/SettingsModal.vue
@@ -36,9 +36,11 @@
             </b-form-checkbox>
           </b-form-group>
           <b-form-group
-            label="Superusers Override Permissions"
-            description="When this is enabled, all WordPress superusers (Administator roles, Editor roles or the
-             Author of this Tapestry) will be able to see and edit all nodes, regardless of the node's set permissions."
+            label="Show Me All Nodes By Default"
+            description="If enabled, editors of this tapestry would be able to see and edit all nodes even 
+            for nodes with the 'read' permission off. If disabled, superusers will be able to use the filter 
+            to view such nodes, but they won't appear in the tapestry by default. Note: Editors of this 
+            tapestry include users with the Administator or Edit roles, and the author of this Tapestry."
           >
             <b-form-checkbox v-model="superuserOverridePermissions" switch>
               {{ superuserOverridePermissions ? "Enabled" : "Disabled" }}

--- a/templates/vue/src/components/TapestryFilter.vue
+++ b/templates/vue/src/components/TapestryFilter.vue
@@ -85,7 +85,6 @@ export default {
     comboboxValueOptions() {
       switch (this.activeFilterOption) {
         case filterOptions.AUTHOR: {
-          // console.log(this.nodes.map(node => [node.author.id, node.author]))
           return this.allContributors !== null
             ? Object.values(this.allContributors)
             : [

--- a/templates/vue/src/services/TapestryAPI.js
+++ b/templates/vue/src/services/TapestryAPI.js
@@ -16,8 +16,11 @@ export default class {
    *
    * @return  {Object}
    */
-  async getTapestry() {
-    const url = `${apiUrl}/tapestries/${this.postId}`
+  async getTapestry(data = {}) {
+    var url = `${apiUrl}/tapestries/${this.postId}`
+    if (data.filterUserId && data.filterUserId !== undefined) {
+      url += "?filter_user_id=" + data.filterUserId
+    }
     const response = await axios.get(url)
     return response.data
   }
@@ -200,5 +203,11 @@ export default class {
       favourites: favourites,
     })
     return response
+  }
+
+  async getAllContributors() {
+    const url = `${apiUrl}/tapestries/contributors?post_id=${this.postId}`
+    const response = await axios.get(url)
+    return response.data
   }
 }

--- a/templates/vue/src/services/TapestryAPI.js
+++ b/templates/vue/src/services/TapestryAPI.js
@@ -206,7 +206,7 @@ export default class {
   }
 
   async getAllContributors() {
-    const url = `${apiUrl}/tapestries/contributors?post_id=${this.postId}`
+    const url = `${apiUrl}/tapestries/${this.postId}/contributors`
     const response = await axios.get(url)
     return response.data
   }

--- a/templates/vue/src/store/actions.js
+++ b/templates/vue/src/store/actions.js
@@ -147,5 +147,4 @@ export async function refetchTapestryData(_, filterUserId = null) {
   thisTapestryTool.setDataset(tapestry)
   thisTapestryTool.setOriginalDataset(tapestry)
   thisTapestryTool.reinitialize()
-  // commit("init", tapestry)
 }

--- a/templates/vue/src/store/actions.js
+++ b/templates/vue/src/store/actions.js
@@ -132,9 +132,18 @@ export async function updateUserFavourites({ commit }, favourites) {
   await client.updateUserFavourites(JSON.stringify(favourites))
 }
 
-export async function refetchTapestryData({ commit }, filterUserId = null) {
+export async function refetchTapestryData(_, filterUserId = null) {
   const query = filterUserId === null ? {} : { filterUserId: filterUserId }
   const tapestry = await client.getTapestry(query)
+  tapestry.nodes.map(n => {
+    if (tapestry.settings.autoLayout) {
+      delete n.fx
+      delete n.fy
+    } else {
+      n.fx = n.coordinates.x
+      n.fy = n.coordinates.y
+    }
+  })
   thisTapestryTool.setDataset(tapestry)
   thisTapestryTool.setOriginalDataset(tapestry)
   thisTapestryTool.reinitialize()

--- a/templates/vue/src/store/actions.js
+++ b/templates/vue/src/store/actions.js
@@ -131,3 +131,12 @@ export async function updateUserFavourites({ commit }, favourites) {
   commit("updateFavourites", { favourites })
   await client.updateUserFavourites(JSON.stringify(favourites))
 }
+
+export async function refetchTapestryData({ commit }, filterUserId = null) {
+  const query = filterUserId === null ? {} : { filterUserId: filterUserId }
+  const tapestry = await client.getTapestry(query)
+  thisTapestryTool.setDataset(tapestry)
+  thisTapestryTool.setOriginalDataset(tapestry)
+  thisTapestryTool.reinitialize()
+  // commit("init", tapestry)
+}

--- a/utilities/class.tapestry-helpers.php
+++ b/utilities/class.tapestry-helpers.php
@@ -148,14 +148,13 @@ class TapestryHelpers
     {
 
         $options = TapestryNodePermissions::getNodePermissions();
-        $groupIds = self::getGroupIdsOfUser($userId, $tapestryPostId);
         $nodePostId = get_metadata_by_mid('post', $nodeMetaId)->meta_value->post_id;
         $userId = $_userId;
         if(is_null($userId)){
             $userId = wp_get_current_user()->ID;
         }
+        $groupIds = self::getGroupIdsOfUser($userId, $tapestryPostId);
         $roles = new TapestryUserRoles($userId);
-        error_log("userId is null: " . is_null($userId));
 
         if (($roles->canEdit($tapestryPostId) && $superuser_override) || $roles->isAuthorOfThePost($nodePostId)) {
             return true;

--- a/utilities/class.tapestry-helpers.php
+++ b/utilities/class.tapestry-helpers.php
@@ -144,18 +144,20 @@ class TapestryHelpers
      *
      * @return  Boolean
      */
-    public static function currentUserIsAllowed($action, $nodeMetaId, $tapestryPostId)
+    public static function userIsAllowed($action, $nodeMetaId, $tapestryPostId, $superuser_override = true, $_userId = null)
     {
+
         $options = TapestryNodePermissions::getNodePermissions();
-        $userId = wp_get_current_user()->ID;
         $groupIds = self::getGroupIdsOfUser($userId, $tapestryPostId);
         $nodePostId = get_metadata_by_mid('post', $nodeMetaId)->meta_value->post_id;
+        $userId = $_userId;
+        if(is_null($userId)){
+            $userId = wp_get_current_user()->ID;
+        }
+        $roles = new TapestryUserRoles($userId);
+        error_log("userId is null: " . is_null($userId));
 
-        if ((TapestryUserRoles::isEditor())
-            || (TapestryUserRoles::isAdministrator())
-            || (TapestryUserRoles::isAuthorOfThePost($tapestryPostId))
-            || (TapestryUserRoles::isAuthorOfThePost($nodePostId))
-        ) {
+        if (($roles->canEdit($tapestryPostId) && $superuser_override) || $roles->isAuthorOfThePost($nodePostId)) {
             return true;
         } else {
             $nodePermissions = get_metadata_by_mid('post', $nodeMetaId)->meta_value->permissions;

--- a/utilities/class.tapestry-helpers.php
+++ b/utilities/class.tapestry-helpers.php
@@ -153,11 +153,10 @@ class TapestryHelpers
      */
     public static function userIsAllowed($action, $nodeMetaId, $tapestryPostId, $superuser_override = true, $_userId = null)
     {
-
         $options = TapestryNodePermissions::getNodePermissions();
         $nodePostId = get_metadata_by_mid('post', $nodeMetaId)->meta_value->post_id;
         $userId = $_userId;
-        if(is_null($userId)){
+        if (is_null($userId)) {
             $userId = wp_get_current_user()->ID;
         }
         $groupIds = self::getGroupIdsOfUser($userId, $tapestryPostId);

--- a/utilities/class.tapestry-user-roles.php
+++ b/utilities/class.tapestry-user-roles.php
@@ -4,11 +4,29 @@
  */
 class TapestryUserRoles
 {
-    public static function canEdit($postId = 0)
+    private $user = null;
+    
+    /**
+     * Constructor
+     *
+     * @param   Number  $postId     post ID
+     * @param   Number  $nodeMetaId node meta ID
+     *
+     * @return  NULL
+     */
+    public function __construct($_userId = null)
     {
-        return TapestryUserRoles::isEditor()
-        || TapestryUserRoles::isAdministrator()
-        || TapestryUserRoles::isAuthorOfThePost($postId);
+        $this->user = get_user_by('id', $_userId);
+        if(is_null($this->user) || !$this->user){
+            $this->user = wp_get_current_user();
+        }
+    }
+
+    public function canEdit($postId = 0)
+    {
+        return $this->isEditor()
+        || $this->isAdministrator()
+        || $this->isAuthorOfThePost($postId);
     }
 
     /**
@@ -16,11 +34,11 @@ class TapestryUserRoles
      *
      * @return Boolean
      */
-    public static function isRole($role)
+    public function isRole($role)
     {
         return in_array(
             $role,
-            wp_get_current_user()->roles
+            $this->user->roles
         );
     }
 
@@ -29,9 +47,9 @@ class TapestryUserRoles
      *
      * @return Boolean
      */
-    public static function isAdministrator()
+    public function isAdministrator()
     {
-        return TapestryUserRoles::isRole('administrator');
+        return $this->isRole('administrator');
     }
 
     /**
@@ -39,9 +57,9 @@ class TapestryUserRoles
      *
      * @return Boolean
      */
-    public static function isEditor()
+    public function isEditor()
     {
-        return TapestryUserRoles::isRole('editor');
+        return $this->isRole('editor');
     }
 
     /**
@@ -49,9 +67,9 @@ class TapestryUserRoles
      *
      * @return Boolean
      */
-    public static function isAuthor()
+    public function isAuthor()
     {
-        return TapestryUserRoles::isRole('author');
+        return $this->isRole('author');
     }
 
     /**
@@ -61,10 +79,9 @@ class TapestryUserRoles
      *
      * @return  Boolean
      */
-    public static function isAuthorOfThePost($postId)
+    public function isAuthorOfThePost($postId)
     {
-        return wp_get_current_user()->ID
-            == get_post($postId)->post_author;
+        return $this->user->ID == get_post($postId)->post_author;
     }
 
     /**
@@ -72,8 +89,8 @@ class TapestryUserRoles
      *
      * @return Boolean
      */
-    public static function isSubscriber()
+    public function isSubscriber()
     {
-        return TapestryUserRoles::isRole('subscriber');
+        return $this->isRole('subscriber');
     }
 }

--- a/utilities/class.tapestry-user-roles.php
+++ b/utilities/class.tapestry-user-roles.php
@@ -5,19 +5,19 @@
 class TapestryUserRoles
 {
     private $user = null;
-    
+
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param   Number  $postId     post ID
-     * @param   Number  $nodeMetaId node meta ID
+     * @param Number $postId     post ID
+     * @param Number $nodeMetaId node meta ID
      *
-     * @return  NULL
+     * @return null
      */
     public function __construct($_userId = null)
     {
         $this->user = get_user_by('id', $_userId);
-        if(is_null($this->user) || !$this->user){
+        if (is_null($this->user) || !$this->user) {
             $this->user = wp_get_current_user();
         }
     }


### PR DESCRIPTION
Closes #628 

Changes: 
 - Add new `superuserOverridesPermission` flag to settings. This is true by default.
 - Add `userId` parameter to `getTapestry` endpoint. If specified, this second user's authored nodes are returned with the current user's, overriding read permissions.
 - Refactored `tapestry-user-roles.php` to no longer be static, and to take a userId argument. Changed all calls to it's functions in the backend to work as objects calls.
- Added `getAllContributors` endpoint to `tapestry.php`. This returns a list of unique authors of nodes within the tapestry.

Steps to test:
1. Login as your tapestry author/editor.
2. Create a node with public add/edit permissions and another with non-public read access.
3. Log out, and log in as another user which is not a super user. 
Superusers are either: Author of the Tapestry, Administator role on WP or Editor role on WP
4. As this non-superuser, you should only be able to see the node with all public permissions.
5. Create a new node as the non-superuser. Turn it's public read permissions off, so only that user can view it.
6. Log back into the admin account and verify the superuser can see all 3 nodes in the tapestry
7. Go to settings and flip the `superuserOverridesPermission` flag to false
8. After reload, verify the superuser can no longer see the 2nd account's node. Check the backend and ensure the visible nodes are the only ones within the dataset.
9. Activate the filter, and select the 2nd user's node as filtered
10. Ensure the 2nd users nodes appear along with the 1st.
11. Deactivate the filter and ensure the nodes go back to the original state. Check the backend and ensure the visible nodes are the only ones within the dataset.
