### PR TITLE
Fix hot reload

### DIFF
--- a/templates/vue/webpack.config.js
+++ b/templates/vue/webpack.config.js
@@ -1,12 +1,12 @@
 var path = require('path')
 var webpack = require('webpack')
-require("babel-polyfill");
+require('babel-polyfill');
 
 module.exports = {
   entry: ['babel-polyfill', './src/main.js'],
   output: {
     path: path.resolve(__dirname, './dist'),
-    publicPath: "/dist/",
+    publicPath: '/dist/',
     filename: 'build.js'
   },
   module: {
@@ -56,7 +56,7 @@ module.exports = {
     historyApiFallback: true,
     noInfo: true,
     overlay: true,
-    headers: { "Access-Control-Allow-Origin": "*" },
+    headers: { 'Access-Control-Allow-Origin': '*' },
     hot: true,
     port: 8080
   },

--- a/templates/vue/webpack.config.js
+++ b/templates/vue/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   entry: ['babel-polyfill', './src/main.js'],
   output: {
     path: path.resolve(__dirname, './dist'),
-    publicPath: '/dist/',
+    publicPath: "http://localhost:8080/dist/",
     filename: 'build.js'
   },
   module: {

--- a/templates/vue/webpack.config.js
+++ b/templates/vue/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   entry: ['babel-polyfill', './src/main.js'],
   output: {
     path: path.resolve(__dirname, './dist'),
-    publicPath: "http://localhost:8080/dist/",
+    publicPath: "/dist/",
     filename: 'build.js'
   },
   module: {
@@ -58,11 +58,16 @@ module.exports = {
     overlay: true,
     headers: { "Access-Control-Allow-Origin": "*" },
     hot: true,
+    port: 8080
   },
   performance: {
     hints: false
   },
   devtool: '#eval-source-map'
+}
+
+if (process.env.NODE_ENV === 'development') {
+  module.exports.output.publicPath = 'http://localhost:8080/dist/'
 }
 
 if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
Closes #643 

This changes some config for when app is being run in ENV = development.

Now, instead of the whole page reloading, only edited components will change.

To test, just make any change on a vue component. You should see this in console.

![tapestry pr644](https://user-images.githubusercontent.com/28816649/87469588-5d746500-c5d0-11ea-98a1-4d6cd06324c1.PNG)

The component should change without the whole page refreshing.