### PR TITLE
650- WordPress content titles become distorted in Tapestry

### DIFF
--- a/tapestry.php
+++ b/tapestry.php
@@ -316,3 +316,19 @@ function gf_button_ajax_get_form()
     die();
 }
 // End of Gravity Forms Pluggin
+
+function replace_special_apostrophe($str) {
+  return str_replace("’", "'", $str);
+}
+
+$quote_style = "ENT_QUOTES";
+add_filter( "rest_prepare_post", 'prefix_title_entity_decode'); 
+function prefix_title_entity_decode($response){
+    $data = $response->get_data();
+    $data['title']['rendered'] = wp_specialchars_decode(html_entity_decode( $data['title']['rendered']), $quote_style);
+    $data['title']['rendered'] = replace_special_apostrophe( $data['title']['rendered']);
+    $data['content']['rendered'] = wp_specialchars_decode(html_entity_decode( $data['content']['rendered']), $quote_style);
+    $data['content']['rendered'] = replace_special_apostrophe( $data['content']['rendered']);
+    $response->set_data($data);
+    return $response;
+}

--- a/templates/vue/src/components/Combobox.vue
+++ b/templates/vue/src/components/Combobox.vue
@@ -16,7 +16,7 @@
         @mousedown.prevent="handleClick(option)"
       >
         <div class="combobox-item">
-          <slot :option="option">{{ option.toString() }}</slot>
+          <slot :option="option"></slot>
         </div>
       </button>
     </div>
@@ -119,11 +119,11 @@ export default {
   },
   watch: {
     text(newText) {
-      this.inputValue = newText
+      this.inputValue = this.decodeHtmlEntity(newText)
     },
   },
   created() {
-    this.inputValue = this.text
+    this.inputValue = this.decodeHtmlEntity(this.text)
   },
   methods: {
     handleBlur() {
@@ -133,13 +133,14 @@ export default {
         if (this.inputValue.length === 0) {
           this.$emit("input", null)
         } else if (this.inputValue !== this.text && !this.selected) {
-          this.inputValue = this.text
+          this.inputValue = this.decodeHtmlEntity(this.text)
         }
       })
     },
     handleClick(option) {
       this.$emit("input", this.getValue(option))
       this.inputValue = this.itemText ? option[this.itemText] : option
+      this.inputValue = this.decodeHtmlEntity(this.inputValue)
       this.selected = true
       this.$refs.input.blur()
     },
@@ -150,6 +151,11 @@ export default {
     },
     getValue(option) {
       return typeof option === "string" ? option : option[this.itemValue]
+    },
+    decodeHtmlEntity(str) {
+      return str.replace(/&#(\d+);/g, function(match, dec) {
+        return String.fromCharCode(dec)
+      })
     },
   },
 }

--- a/templates/vue/src/components/Combobox.vue
+++ b/templates/vue/src/components/Combobox.vue
@@ -119,11 +119,11 @@ export default {
   },
   watch: {
     text(newText) {
-      this.inputValue = this.decodeHtmlEntity(newText)
+      this.inputValue = newText
     },
   },
   created() {
-    this.inputValue = this.decodeHtmlEntity(this.text)
+    this.inputValue = this.text
   },
   methods: {
     handleBlur() {
@@ -133,14 +133,13 @@ export default {
         if (this.inputValue.length === 0) {
           this.$emit("input", null)
         } else if (this.inputValue !== this.text && !this.selected) {
-          this.inputValue = this.decodeHtmlEntity(this.text)
+          this.inputValue = this.text
         }
       })
     },
     handleClick(option) {
       this.$emit("input", this.getValue(option))
       this.inputValue = this.itemText ? option[this.itemText] : option
-      this.inputValue = this.decodeHtmlEntity(this.inputValue)
       this.selected = true
       this.$refs.input.blur()
     },
@@ -151,11 +150,6 @@ export default {
     },
     getValue(option) {
       return typeof option === "string" ? option : option[this.itemValue]
-    },
-    decodeHtmlEntity(str) {
-      return str.replace(/&#(\d+);/g, function(match, dec) {
-        return String.fromCharCode(dec)
-      })
     },
   },
 }

--- a/templates/vue/src/components/Combobox.vue
+++ b/templates/vue/src/components/Combobox.vue
@@ -49,7 +49,7 @@ export default {
       required: true,
     },
     value: {
-      type: [Object, String],
+      type: [Object, String, Number],
       required: false,
       default: null,
     },

--- a/templates/vue/src/components/lightbox/WpPostMedia.vue
+++ b/templates/vue/src/components/lightbox/WpPostMedia.vue
@@ -1,7 +1,7 @@
 <template>
   <loading v-if="loading" />
   <div v-else class="article">
-    <h1 class="article-title">{{ title }}</h1>
+    <h1 class="article-title" v-html="title"></h1>
     <article v-html="content"></article>
   </div>
 </template>

--- a/templates/vue/src/components/node-modal/content-form/WpPostForm.vue
+++ b/templates/vue/src/components/node-modal/content-form/WpPostForm.vue
@@ -8,10 +8,8 @@
       :options="wpPosts"
     >
       <template v-slot="slotProps">
-        <p>
-          <code>{{ slotProps.option.id }}</code>
-          {{ slotProps.option.title }}
-        </p>
+        <code>{{ slotProps.option.id }}</code>
+        <p v-html="slotProps.option.title"></p>
       </template>
     </combobox>
   </b-form-group>


### PR DESCRIPTION
Closes #650

Renders post titles with v-html directive in WpPostMedia.vue, so special characters such as apostrophes are not rendered as literal unicode.

Some backend changes to how title and content is returned, and parsing is done there. Changed how apostrophes are handled so it matches commonly typed apostrophe.