### PR TITLE
656 - Bug fix: Duplicated Tapestry name reverts when Tapestry is modified

### DIFF
--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -437,11 +437,6 @@ class Tapestry implements ITapestry
     {
         $tapestry = $this->_formTapestry();
 
-        if ($this->updateTapestryPost) {
-            $this->postId = TapestryHelpers::updatePost($tapestry, 'tapestry', $this->postId);
-            $this->_resetAuthor();
-        }
-
         update_post_meta($this->postId, 'tapestry', $tapestry);
 
         return $tapestry;


### PR DESCRIPTION
Closes #656