### PR TITLE
655 - WordPress posts only search within the first 10 posts 

### DIFF
--- a/templates/vue/src/components/node-modal/content-form/WpPostForm.vue
+++ b/templates/vue/src/components/node-modal/content-form/WpPostForm.vue
@@ -41,7 +41,6 @@ export default {
     WordpressApi.getPosts().then(posts => {
       this.wpPosts = posts
     })
-
   },
 }
 </script>

--- a/templates/vue/src/components/node-modal/content-form/WpPostForm.vue
+++ b/templates/vue/src/components/node-modal/content-form/WpPostForm.vue
@@ -4,7 +4,7 @@
       v-model="node.typeData.mediaURL"
       item-text="title"
       item-value="id"
-      empty-message="There are no Wordpress posts yet. Please add one in your WP dashboard."
+      :empty-message="emptyMessage"
       :options="wpPosts"
     >
       <template v-slot="slotProps">
@@ -34,13 +34,21 @@ export default {
   data() {
     return {
       wpPosts: [],
+      emptyMessage: "Wordpress posts are loading...",
     }
   },
   mounted() {
     this.wpPosts = WordpressApi.loadCachedPosts()
-    WordpressApi.getPosts().then(posts => {
-      this.wpPosts = posts
-    })
+    WordpressApi.getPosts()
+      .then(posts => {
+        this.wpPosts = posts
+      })
+      .then(() => {
+        if (this.wpPosts.length < 1) {
+          this.emptyMessage =
+            "There are no Wordpress posts yet. Please add one in your WP dashboard."
+        }
+      })
   },
 }
 </script>

--- a/templates/vue/src/components/node-modal/content-form/WpPostForm.vue
+++ b/templates/vue/src/components/node-modal/content-form/WpPostForm.vue
@@ -37,9 +37,11 @@ export default {
     }
   },
   mounted() {
+    this.wpPosts = WordpressApi.loadCachedPosts()
     WordpressApi.getPosts().then(posts => {
       this.wpPosts = posts
     })
+
   },
 }
 </script>

--- a/templates/vue/src/services/WordpressApi.js
+++ b/templates/vue/src/services/WordpressApi.js
@@ -6,22 +6,22 @@ let wp_posts_cache = []
 
 function loadCachedPosts() {
   if (wp_posts_cache.length > 0) {
-    return wp_posts_cache;
+    return wp_posts_cache
   } else {
-    return [];
+    return []
   }
 }
 
 async function getPosts() {
   let posts = []
   const res = await axios.get(`${API_URL}/posts?per_page=1`)
-  let totalPages = Math.ceil(res.headers["x-wp-total"] / 100);
+  let totalPages = Math.ceil(res.headers["x-wp-total"] / 100)
   let arr = []
   for (let i = 1; i <= totalPages; i++) {
-    arr[i-1] = i;
+    arr[i - 1] = i
   }
   await Promise.all(
-    arr.map(async (page) => {
+    arr.map(async page => {
       const res = await axios.get(`${API_URL}/posts?page=${page}&per_page=100`)
       posts = posts.concat(res.data)
     })

--- a/templates/vue/src/services/WordpressApi.js
+++ b/templates/vue/src/services/WordpressApi.js
@@ -3,10 +3,19 @@ import axios from "axios"
 const API_URL = `${wpData.rest_url}/wp/v2`
 
 async function getPosts() {
-  return axios.get(`${API_URL}/posts`).then(res => {
-    const { data } = res
-    return data.map(parsePost)
-  })
+  let totalPages
+  let posts = []
+  const res = await axios.get(`${API_URL}/posts`)
+  console.log(res.headers["x-wp-totalpages"])
+  totalPages = res.headers["x-wp-totalpages"]
+  console.log("total pages" + totalPages)
+  for (let i = 1; i <= totalPages; i++) {
+    const res = await axios.get(`${API_URL}/posts?page=${i}`)
+    console.log(res.data)
+    posts = posts.concat(res.data)
+  }
+  console.log(posts)
+  return posts.map(parsePost)
 }
 
 async function getPostById(id) {

--- a/templates/vue/src/services/WordpressApi.js
+++ b/templates/vue/src/services/WordpressApi.js
@@ -20,7 +20,6 @@ async function getPosts() {
   for (let i = 1; i <= totalPages; i++) {
     arr[i - 1] = i
   }
-  console.time()
   await Promise.all(
     arr.map(async page => {
       const res = await axios.get(
@@ -29,7 +28,6 @@ async function getPosts() {
       posts = posts.concat(res.data)
     })
   )
-  console.timeEnd()
   wp_posts_cache = posts.map(post => ({
     ...post,
     title: post.title.rendered,

--- a/templates/vue/src/services/WordpressApi.js
+++ b/templates/vue/src/services/WordpressApi.js
@@ -14,25 +14,32 @@ function loadCachedPosts() {
 
 async function getPosts() {
   let posts = []
-  const res = await axios.get(`${API_URL}/posts?per_page=1`)
+  const res = await axios.get(`${API_URL}/posts?per_page=1&_fields=id`)
   let totalPages = Math.ceil(res.headers["x-wp-total"] / 100)
   let arr = []
   for (let i = 1; i <= totalPages; i++) {
     arr[i - 1] = i
   }
+  console.time()
   await Promise.all(
     arr.map(async page => {
-      const res = await axios.get(`${API_URL}/posts?page=${page}&per_page=100`)
+      const res = await axios.get(
+        `${API_URL}/posts?page=${page}&per_page=100&_fields=id,title`
+      )
       posts = posts.concat(res.data)
     })
   )
-  wp_posts_cache = posts.map(parsePost)
-  return posts.map(parsePost)
+  console.timeEnd()
+  wp_posts_cache = posts.map(post => ({
+    ...post,
+    title: post.title.rendered,
+  }))
+  return wp_posts_cache
 }
 
 async function getPostById(id) {
   return axios
-    .get(`${API_URL}/posts/${id}`)
+    .get(`${API_URL}/posts/${id}&_fields=id,title,content`)
     .then(res => res.data)
     .then(parsePost)
 }


### PR DESCRIPTION
Instead of just fetching only 10 posts, we now fetch all posts from our database. 
The query may take a long time - about 13 seconds for 330 posts, so they will be cached after the first time the call is made. Thus the user may peruse options from last time (which probably will be more or less the same) as we fetch again in the background. There is a different empty message now for when posts are being fetched.

I tried to optimize it as much as possible, but we're getting bottlenecked by the WP api speed.
~~For reference, on my machine with postman, calling the first page of all posts with a 100 limit needs 11 secs to complete, while setting the limit to 10 only reduces that time to 7 secs.~~
After removing unnecessary info from the api call we are down to a bit over 6 secs for 100 posts at a time on my machine, Aidin's has it at under 2 seconds which is good. Mine just might be slow. 



There is an extension called fakerPress which helps generate fake posts (for testing).

Closes #655 