### PR TITLE
662 - [TYDE] Bug fix: Copilots cannot access their nodes if it depends on a teen node

### DIFF
--- a/classes/class.tapestry-node.php
+++ b/classes/class.tapestry-node.php
@@ -246,10 +246,16 @@ class TapestryNode implements ITapestryNode
         foreach ($conditions as $condition) {
             switch ($condition->type) {
                 case ConditionTypes::NODE_COMPLETED:
-                    if ($userId && $userProgress->isCompleted($condition->nodeId, $userId)) {
-                        $condition->fulfilled = true;
+                    $user = get_userdata($userId);
+                    if ($user) {
+                        $isCopilot = in_array('copilot', $user->roles);
+                        $workingUserId = $isCopilot ? get_the_author_meta('teen_id', $userId) : $userId;
+                        if ($userProgress->isCompleted($condition->nodeId, $workingUserId)) {
+                            $condition->fulfilled = true;
+                        }
                     }
                     break;
+
                 case ConditionTypes::DATE_NOT_PASSED:
                     if (new DateTime() <= new DateTime($condition->date.' '.$condition->time, new DateTimeZone($condition->timezone))) {
                         $condition->fulfilled = true;

--- a/classes/class.tapestry-node.php
+++ b/classes/class.tapestry-node.php
@@ -246,7 +246,7 @@ class TapestryNode implements ITapestryNode
         foreach ($conditions as $condition) {
             switch ($condition->type) {
                 case ConditionTypes::NODE_COMPLETED:
-                    if ($userProgress->isCompleted($condition->nodeId, $userId)) {
+                    if ($userId && $userProgress->isCompleted($condition->nodeId, $userId)) {
                         $condition->fulfilled = true;
                     } else {
                         // If user is a co-pilot, also check the completion of node by teen

--- a/classes/class.tapestry-node.php
+++ b/classes/class.tapestry-node.php
@@ -246,12 +246,16 @@ class TapestryNode implements ITapestryNode
         foreach ($conditions as $condition) {
             switch ($condition->type) {
                 case ConditionTypes::NODE_COMPLETED:
-                    $user = get_userdata($userId);
-                    if ($user) {
-                        $isCopilot = in_array('copilot', $user->roles);
-                        $workingUserId = $isCopilot ? get_the_author_meta('teen_id', $userId) : $userId;
-                        if ($userProgress->isCompleted($condition->nodeId, $workingUserId)) {
-                            $condition->fulfilled = true;
+                    if ($userProgress->isCompleted($condition->nodeId, $userId)) {
+                        $condition->fulfilled = true;
+                    } else {
+                        // If user is a co-pilot, also check the completion of node by teen
+                        $user = get_userdata($userId);
+                        if (in_array('copilot', $user->roles)) {
+                            $teenUserId = get_the_author_meta('teen_id', $userId);
+                            if ($teenUserId && $userProgress->isCompleted($condition->nodeId, $teenUserId)) {
+                                $condition->fulfilled = true;
+                            }
                         }
                     }
                     break;

--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -368,17 +368,15 @@ class Tapestry implements ITapestry
         $node->accessible = $node->unlocked;
         if ($node->accessible) {
             $neighbourIds = $this->_getNeighbours($node);
+            $neighbours = [];
 
-            $neighbours = array_map(
-                function ($nodeId) use ($nodeList) {
-                    foreach ($nodeList as $otherNode) {
-                        if ($otherNode->id === $nodeId) {
-                            return $otherNode;
-                        }
+            foreach ($neighbourIds as $nodeId) {
+                foreach ($nodeList as $otherNode) {
+                    if ($otherNode->id === $nodeId) {
+                        array_push($neighbours, $otherNode);
                     }
-                },
-                $neighbourIds
-            );
+                }
+            }
 
             foreach ($neighbours as $neighbour) {
                 if (!in_array($neighbour, $visited)) {
@@ -547,8 +545,7 @@ class Tapestry implements ITapestry
             return false;
         }
 
-        if (TapestryHelpers::currentUserIsAllowed('READ', $from, $this->postId) || (TapestryHelpers::currentUserIsAllowed('ADD', $from, $this->postId) || TapestryHelpers::currentUserIsAllowed('EDIT', $from, $this->postId)))
-        {
+        if (TapestryHelpers::currentUserIsAllowed('READ', $from, $this->postId) || (TapestryHelpers::currentUserIsAllowed('ADD', $from, $this->postId) || TapestryHelpers::currentUserIsAllowed('EDIT', $from, $this->postId))) {
             if ($from == $to) {
                 return true;
             }

--- a/templates/vue/src/components/TapestryMedia.vue
+++ b/templates/vue/src/components/TapestryMedia.vue
@@ -96,7 +96,7 @@ import GravityForm from "./lightbox/GravityForm"
 import WpPostMedia from "./lightbox/WpPostMedia"
 import CompletionScreen from "./lightbox/quiz-screen/CompletionScreen"
 import QuizMedia from "./lightbox/QuizMedia"
-import YouTubeMedia from "./lightbox/YoutubeMedia"
+import YouTubeMedia from "./lightbox/YouTubeMedia"
 import Helpers from "@/utils/Helpers"
 
 const SAVE_INTERVAL = 5000


### PR DESCRIPTION
Closes #662

This PR fixes an issue where a copilot node will never be accessible if its locking condition is dependent on the completion of a teen-only node (a regular node).

The bug occurred because the old code only checks if the user has completed the node specified by the locking condition. Copilots will never complete a teen node because they are not able to update the teen's progress.

The fix works by checking if the current user is a copilot, and if they are, check if their associated **teen** has completed the node instead.