### PR TITLE
[No ticket] Fix hot reload not working in 482

### DIFF
--- a/templates/vue/config/webpack.dev.js
+++ b/templates/vue/config/webpack.dev.js
@@ -4,10 +4,15 @@ const baseConfig = require("./webpack.base")
 
 module.exports = merge(baseConfig, {
   mode: "development",
+  output: {
+    publicPath: "http://localhost:8080/dist/",
+  },
   devServer: {
+    headers: { "Access-Control-Allow-Origin": "*" },
     contentBase: path.resolve(__dirname, "../dist"),
     publicPath: "/dist/",
     port: 8080,
+    hot: true,
   },
   devtool: "inline-source-map",
 })


### PR DESCRIPTION
After #482 was merged in, hot reload was broken because I hadn't correctly migrated some parts of the old webpack config over to webpack 4. This PR fixes these issues.