### PR TITLE
730 - Bug fix: Tapestry Depth setting showing incorrect max depth

### DIFF
--- a/templates/vue/src/components/SettingsModal.vue
+++ b/templates/vue/src/components/SettingsModal.vue
@@ -131,7 +131,6 @@
 
 <script>
 import { mapGetters, mapState } from "vuex"
-import { bus } from "@/utils/event-bus"
 import FileUpload from "./FileUpload"
 import DuplicateTapestryButton from "./settings-modal/DuplicateTapestryButton"
 import PermissionsTable from "./node-modal/PermissionsTable"
@@ -158,6 +157,10 @@ export default {
       type: Boolean,
       required: true,
     },
+    maxDepth: {
+      type: Number,
+      required: true,
+    },
   },
   data() {
     return {
@@ -169,7 +172,6 @@ export default {
       fileUploading: false,
       superuserOverridePermissions: true,
       defaultDepth: 3,
-      maxDepth: 0,
       renderImages: true,
     }
   },
@@ -181,9 +183,6 @@ export default {
     if (this.settings.defaultPermissions) {
       this.defaultPermissions = this.settings.defaultPermissions
     }
-    bus.$on("max-depth-change", depth => {
-      this.maxDepth = depth
-    })
   },
   mounted() {
     this.getSettings()

--- a/templates/vue/src/components/SettingsModal.vue
+++ b/templates/vue/src/components/SettingsModal.vue
@@ -200,7 +200,7 @@ export default {
         defaultPermissions = this.defaultPermissions,
         showAccess = true,
         superuserOverridePermissions = true,
-        defaultDepth = Math.max(this.maxDepth, 3),
+        defaultDepth = 3,
         renderImages = true,
       } = this.settings
       this.backgroundUrl = backgroundUrl
@@ -220,7 +220,7 @@ export default {
         defaultPermissions: this.defaultPermissions,
         showAccess: this.showAccess,
         superuserOverridePermissions: this.superuserOverridePermissions,
-        defaultDepth: Math.max(this.maxDepth, parseInt(this.defaultDepth)),
+        defaultDepth: parseInt(this.defaultDepth),
         renderImages: this.renderImages,
       })
       await this.$store.dispatch("updateSettings", settings)

--- a/templates/vue/src/components/SettingsModal.vue
+++ b/templates/vue/src/components/SettingsModal.vue
@@ -181,10 +181,12 @@ export default {
     if (this.settings.defaultPermissions) {
       this.defaultPermissions = this.settings.defaultPermissions
     }
+    bus.$on("max-depth-change", depth => {
+      this.maxDepth = depth
+    })
   },
   mounted() {
-    this.getSettings()
-    bus.$on("max-depth-change", depth => (this.maxDepth = depth))
+    this.getSettings()   
   },
   methods: {
     closeModal() {
@@ -198,7 +200,7 @@ export default {
         defaultPermissions = this.defaultPermissions,
         showAccess = true,
         superuserOverridePermissions = true,
-        defaultDepth = 3,
+        defaultDepth = Math.max(this.maxDepth, 3),
         renderImages = true,
       } = this.settings
       this.backgroundUrl = backgroundUrl
@@ -218,7 +220,7 @@ export default {
         defaultPermissions: this.defaultPermissions,
         showAccess: this.showAccess,
         superuserOverridePermissions: this.superuserOverridePermissions,
-        defaultDepth: parseInt(this.defaultDepth),
+        defaultDepth: Math.max(this.maxDepth, parseInt(this.defaultDepth)),
         renderImages: this.renderImages,
       })
       await this.$store.dispatch("updateSettings", settings)

--- a/templates/vue/src/components/SettingsModalButton.vue
+++ b/templates/vue/src/components/SettingsModalButton.vue
@@ -3,6 +3,7 @@
     <tapestry-icon icon="cog"></tapestry-icon>
     <settings-modal
       :show="settingsModalOpen"
+      :max-depth="maxDepth"
       @close="this.closeModal"
     ></settings-modal>
   </button>
@@ -16,6 +17,12 @@ export default {
   components: {
     SettingsModal,
     TapestryIcon,
+  },
+  props: {
+    maxDepth: {
+      type: Number,
+      required: true,
+    },
   },
   data() {
     return {

--- a/templates/vue/src/components/TapestryApp.vue
+++ b/templates/vue/src/components/TapestryApp.vue
@@ -3,8 +3,14 @@
     <div class="toolbar">
       <tapestry-filter style="z-index: 10;" />
       <div class="slider-wrapper">
-        <settings-modal-button v-if="canEdit"></settings-modal-button>
-        <tapestry-depth-slider @change="updateViewBox"></tapestry-depth-slider>
+        <settings-modal-button
+          v-if="canEdit"
+          :max-depth="maxDepth"
+        ></settings-modal-button>
+        <tapestry-depth-slider
+          @change="updateViewBox"
+          @change:max-depth="maxDepth = $event"
+        ></tapestry-depth-slider>
       </div>
     </div>
     <root-node-button
@@ -74,6 +80,7 @@ export default {
       loading: true,
       viewBox: "2200 2700 1600 1100",
       activeNode: null,
+      maxDepth: 0,
     }
   },
   computed: {

--- a/templates/vue/src/components/TapestryDepthSlider.vue
+++ b/templates/vue/src/components/TapestryDepthSlider.vue
@@ -20,7 +20,6 @@
 <script>
 import { mapState, mapGetters, mapMutations } from "vuex"
 import TapestryIcon from "@/components/TapestryIcon"
-import { bus } from "@/utils/event-bus"
 
 export default {
   components: {
@@ -87,7 +86,7 @@ export default {
     maxDepth: {
       immediate: true,
       handler: function(maxDepth) {
-        bus.$emit("max-depth-change", maxDepth)
+        this.$emit("change:max-depth", maxDepth)
       },
     },
   },


### PR DESCRIPTION
Closes #730 
Moves bus listener from mounted hook to created hook for SettingsModal so it may actually receive the emits from maxDepth changing.