### PR TITLE
738 - Public users should not be able to add or edit

### DIFF
--- a/endpoints.php
+++ b/endpoints.php
@@ -620,8 +620,13 @@ function deleteTapestryLink($request)
         if ($postId && !TapestryHelpers::isValidTapestry($postId)) {
             throw new TapestryError('INVALID_POST_ID');
         }
+        if (!TapestryHelpers::userIsAllowed('ADD', $linkIndex->source, $postId)) {
+            throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
+        }
+        if (!TapestryHelpers::userIsAllowed('ADD', $linkIndex->target, $postId)) {
+            throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
+        }
         $tapestry = new Tapestry($postId);
-
         return $tapestry->removeLink($linkIndex);
     } catch (TapestryError $e) {
         return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());

--- a/endpoints.php
+++ b/endpoints.php
@@ -615,15 +615,17 @@ function addTapestryLink($request)
 function deleteTapestryLink($request)
 {
     $postId = $request['tapestryPostId'];
-    $linkIndex = json_decode($request->get_body());
+    $body = json_decode($request->get_body());
+    $linkIndex = $body->linkIndex;
+    $link = $body->link;
     try {
         if ($postId && !TapestryHelpers::isValidTapestry($postId)) {
             throw new TapestryError('INVALID_POST_ID');
         }
-        if (!TapestryHelpers::userIsAllowed('ADD', $linkIndex->source, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('ADD', $link->source, $postId)) {
             throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
         }
-        if (!TapestryHelpers::userIsAllowed('ADD', $linkIndex->target, $postId)) {
+        if (!TapestryHelpers::userIsAllowed('ADD', $link->target, $postId)) {
             throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
         }
         $tapestry = new Tapestry($postId);

--- a/templates/vue/src/components/TapestryLink.vue
+++ b/templates/vue/src/components/TapestryLink.vue
@@ -12,7 +12,7 @@
       :x2="target.coordinates.x"
       :y1="source.coordinates.y"
       :y2="target.coordinates.y"  
-      v-on="isLoggedIn ? { click: remove } : { click: null }"
+      @click="remove"
     ></line>
   </transition>
 </template>
@@ -55,6 +55,10 @@ export default {
       return sourceNeighbours.length > 0 && targetNeighbours.length > 0
     },
     async remove() {
+      if(event.target.classList.contains("disabled"))
+			{
+				return;
+			}
       const userConfirmDelete = confirm(
         `Are you sure you want to delete the link between ${this.source.title} and ${this.target.title}?`
       )

--- a/templates/vue/src/components/TapestryLink.vue
+++ b/templates/vue/src/components/TapestryLink.vue
@@ -5,18 +5,21 @@
       :class="{
         opaque:
           !visibleNodes.includes(source.id) || !visibleNodes.includes(target.id),
+        disabled:
+          !isLoggedIn,
       }"
       :x1="source.coordinates.x"
       :x2="target.coordinates.x"
       :y1="source.coordinates.y"
-      :y2="target.coordinates.y"
-      @click="remove"
+      :y2="target.coordinates.y"  
+      v-on="isLoggedIn ? { click: remove } : { click: null }"
     ></line>
   </transition>
 </template>
 
 <script>
 import { mapActions, mapGetters, mapState } from "vuex"
+import { isLoggedIn } from "@/utils/wp"
 
 export default {
   name: "tapestry-link",
@@ -35,6 +38,9 @@ export default {
     ...mapGetters(["getNeighbours", "isAccordion", "isVisible"]),
     show() {
       return this.isVisible(this.source.id) && this.isVisible(this.target.id)
+    },
+    isLoggedIn() {
+      return isLoggedIn
     },
   },
   methods: {

--- a/templates/vue/src/components/TapestryNode.vue
+++ b/templates/vue/src/components/TapestryNode.vue
@@ -71,7 +71,7 @@
             </button>
           </foreignObject>
           <add-child-button
-            v-if="isLoggedIn() && hasPermission('add') && !isSubAccordionRow"
+            v-if="isLoggedIn && hasPermission('add') && !isSubAccordionRow"
             :node="node"
             :x="node.coordinates.x - 65"
             :y="node.coordinates.y + radius - 30"
@@ -149,6 +149,9 @@ export default {
       "getParent",
       "isAccordionRow",
     ]),
+    isLoggedIn() {
+      return isLoggedIn
+    },
     isSubAccordionRow() {
       const parent = this.getParent(this.node.id)
       if (parent) {
@@ -350,7 +353,6 @@ export default {
     hasPermission(action) {
       return Helpers.hasPermission(this.node, action)
     },
-    isLoggedIn,
   },
 }
 </script>

--- a/templates/vue/src/components/TapestryNode.vue
+++ b/templates/vue/src/components/TapestryNode.vue
@@ -77,7 +77,7 @@
             :y="node.coordinates.y + radius - 30"
           ></add-child-button>
           <foreignObject
-            v-if="hasPermission('edit')"
+            v-if="isLoggedIn && hasPermission('edit')"
             class="node-button-wrapper"
             :x="node.coordinates.x + 5"
             :y="node.coordinates.y + radius - 30"

--- a/templates/vue/src/components/TapestryNode.vue
+++ b/templates/vue/src/components/TapestryNode.vue
@@ -71,7 +71,7 @@
             </button>
           </foreignObject>
           <add-child-button
-            v-if="hasPermission('add') && !isSubAccordionRow"
+            v-if="isLoggedIn() && hasPermission('add') && !isSubAccordionRow"
             :node="node"
             :x="node.coordinates.x - 65"
             :y="node.coordinates.y + radius - 30"
@@ -114,6 +114,7 @@ import { mapActions, mapGetters, mapState, mapMutations } from "vuex"
 import TapestryIcon from "@/components/TapestryIcon"
 import { bus } from "@/utils/event-bus"
 import Helpers from "@/utils/Helpers"
+import { isLoggedIn } from "@/utils/wp"
 import AddChildButton from "./tapestry-node/AddChildButton"
 import ProgressBar from "./tapestry-node/ProgressBar"
 
@@ -349,6 +350,7 @@ export default {
     hasPermission(action) {
       return Helpers.hasPermission(this.node, action)
     },
+    isLoggedIn,
   },
 }
 </script>

--- a/templates/vue/src/components/node-modal/PermissionsTable.vue
+++ b/templates/vue/src/components/node-modal/PermissionsTable.vue
@@ -140,8 +140,8 @@ export default {
         this.getPermissionRowIndex(rowName)
       ][1]
 
-      // We don't support node additions for public users
-      if (rowName === "public" && type === "add") {
+      // We don't support node additions or editing for public users
+      if (rowName === "public" && (type === "add" || type === "edit")) {
         return true
       }
 

--- a/templates/vue/src/components/node-modal/PermissionsTable.vue
+++ b/templates/vue/src/components/node-modal/PermissionsTable.vue
@@ -140,6 +140,11 @@ export default {
         this.getPermissionRowIndex(rowName)
       ][1]
 
+      // We don't support node additions for public users
+      if (rowName === "public" && type === "add") {
+        return true
+      }
+
       if (
         currentPermissions.includes("add") ||
         currentPermissions.includes("edit")

--- a/templates/vue/src/store/actions.js
+++ b/templates/vue/src/store/actions.js
@@ -197,7 +197,7 @@ export async function deleteLink({ state, commit }, { source, target }) {
   const linkIndex = state.links.findIndex(
     link => link.source === source && link.target === target
   )
-  await client.deleteLink(linkIndex)
+  await client.deleteLink(JSON.stringify({linkIndex: linkIndex, link: state.links[linkIndex]}))
   commit("deleteLink", { source, target })
 }
 

--- a/templates/vue/src/store/mutations.js
+++ b/templates/vue/src/store/mutations.js
@@ -80,6 +80,11 @@ function parseDataset(dataset) {
     dataset.settings.defaultDepth = DEFAULT_DEPTH
   }
 
+  const defaultPublicPerm = dataset.settings.defaultPermissions.public
+  if (defaultPublicPerm.includes("add") || defaultPublicPerm.includes("edit")) {
+    dataset.settings.defaultPermissions.public = ['read'];
+  }
+
   return dataset
 }
 

--- a/templates/vue/src/store/mutations.js
+++ b/templates/vue/src/store/mutations.js
@@ -44,6 +44,11 @@ function parseDataset(dataset) {
     if (mediaURL && typeof mediaURL === "string") {
       node.typeData.mediaURL = mediaURL.replace(/(http(s?)):\/\//gi, "//")
     }
+
+    const publicPermissions = node.permissions.public
+    if (publicPermissions.includes("add")) {
+      node.permissions.public = publicPermissions.filter(perm => perm !== "add")
+    }
   }
 
   for (const node of dataset.nodes.filter(node => node.mediaType === "accordion")) {

--- a/templates/vue/src/store/mutations.js
+++ b/templates/vue/src/store/mutations.js
@@ -47,9 +47,7 @@ function parseDataset(dataset) {
     }
     const publicPermissions = node.permissions.public
     if (publicPermissions.includes("add") || publicPermissions.includes("edit")) {
-      node.permissions.public = publicPermissions.filter(
-        perm => { perm !== "add" && perm !== "edit" }
-      )
+      node.permissions.public = ["read"];
     }
   }
 

--- a/templates/vue/src/store/mutations.js
+++ b/templates/vue/src/store/mutations.js
@@ -46,8 +46,10 @@ function parseDataset(dataset) {
     }
 
     const publicPermissions = node.permissions.public
-    if (publicPermissions.includes("add")) {
-      node.permissions.public = publicPermissions.filter(perm => perm !== "add")
+    if (publicPermissions.includes("add") || publicPermissions.includes("edit")) {
+      node.permissions.public = publicPermissions.filter(
+        perm => perm !== "add" && perm !== "edit"
+      )
     }
   }
 

--- a/templates/vue/src/store/mutations.js
+++ b/templates/vue/src/store/mutations.js
@@ -45,11 +45,10 @@ function parseDataset(dataset) {
     if (mediaURL && typeof mediaURL === "string") {
       node.typeData.mediaURL = mediaURL.replace(/(http(s?)):\/\//gi, "//")
     }
-
     const publicPermissions = node.permissions.public
     if (publicPermissions.includes("add") || publicPermissions.includes("edit")) {
       node.permissions.public = publicPermissions.filter(
-        perm => perm !== "add" && perm !== "edit"
+        perm => { perm !== "add" && perm !== "edit" }
       )
     }
   }

--- a/templates/vue/src/utils/wp.js
+++ b/templates/vue/src/utils/wp.js
@@ -1,0 +1,3 @@
+export function isLoggedIn() {
+  return Boolean(wpData.currentUser.ID)
+}

--- a/templates/vue/src/utils/wp.js
+++ b/templates/vue/src/utils/wp.js
@@ -1,3 +1,1 @@
-export function isLoggedIn() {
-  return Boolean(wpData.currentUser.ID)
-}
+export const isLoggedIn = Boolean(wpData.currentUser.ID)


### PR DESCRIPTION
Closes #738 

This PR removes support for node creation by public users. Specifically:
- The add button will now _always_ be hidden for public users, regardless of the permission set in the node
- The "add" permission checkbox for public users is now disabled, so authors won't be able to set this permission for future nodes
- For current nodes, the add permission is stripped when the node is loaded in