### PR TITLE
746 - Bug fix: Adding child node makes it appear like a grandchild node

### DIFF
--- a/templates/vue/src/components/TapestryDepthSlider.vue
+++ b/templates/vue/src/components/TapestryDepthSlider.vue
@@ -97,7 +97,7 @@ export default {
   methods: {
     ...mapMutations(["updateNode"]),
     setDefaultDepth() {
-      this.currentDepth = this.settings.defaultDepth || this.maxDepth + 1
+      this.currentDepth = this.settings.defaultDepth || 3
     },
     updateNodeTypes() {
       const depth = parseInt(this.currentDepth)

--- a/templates/vue/src/components/TapestryDepthSlider.vue
+++ b/templates/vue/src/components/TapestryDepthSlider.vue
@@ -97,7 +97,7 @@ export default {
   methods: {
     ...mapMutations(["updateNode"]),
     setDefaultDepth() {
-      this.currentDepth = this.settings.defaultDepth || 3
+      this.currentDepth = this.settings.defaultDepth
     },
     updateNodeTypes() {
       const depth = parseInt(this.currentDepth)

--- a/templates/vue/src/store/mutations.js
+++ b/templates/vue/src/store/mutations.js
@@ -1,5 +1,6 @@
 import Vue from "vue"
 import * as getters from "./getters"
+import { DEFAULT_DEPTH } from "@/utils/constants"
 
 export function init(state, { dataset, progress = {} }) {
   const datasetWithProgress = setDatasetProgress(
@@ -69,6 +70,11 @@ function parseDataset(dataset) {
       getNode(dataset, target) !== undefined
     )
   })
+
+  const { defaultDepth } = dataset.settings
+  if (defaultDepth === undefined) {
+    dataset.settings.defaultDepth = DEFAULT_DEPTH
+  }
 
   return dataset
 }

--- a/templates/vue/src/utils/constants.js
+++ b/templates/vue/src/utils/constants.js
@@ -28,3 +28,5 @@ export const licenses = {
     icons: ["fas fa-plus"],
   },
 }
+
+export const DEFAULT_DEPTH = 3


### PR DESCRIPTION
Closes #746 

Changes the default depth to 3 rather than `maxDepth + 1` so that nodes made off an empty Tapestry wouldn't appear as grandchild nodes. I believe this also better reflects the old functionality in `tapestry.js`.