### PR TITLE
741 - Unable to open the settings modal more than one time

### DIFF
--- a/templates/vue/src/components/SettingsModal.vue
+++ b/templates/vue/src/components/SettingsModal.vue
@@ -185,6 +185,10 @@ export default {
   mounted() {
     this.getSettings()
     bus.$on("max-depth-change", depth => (this.maxDepth = depth))
+    this.$root.$on("bv::modal::hide", () => {
+      this.$emit("close")
+      console.log('settings modal going away')
+    })
   },
   methods: {
     closeModal() {

--- a/templates/vue/src/components/SettingsModal.vue
+++ b/templates/vue/src/components/SettingsModal.vue
@@ -1,7 +1,7 @@
 <template>
   <b-modal
     id="settings-modal"
-    v-model="show"
+    :visible="show"
     size="lg"
     title="Tapestry Settings"
     scrollable
@@ -187,7 +187,6 @@ export default {
     bus.$on("max-depth-change", depth => (this.maxDepth = depth))
     this.$root.$on("bv::modal::hide", () => {
       this.$emit("close")
-      console.log('settings modal going away')
     })
   },
   methods: {

--- a/templates/vue/src/components/SettingsModalButton.vue
+++ b/templates/vue/src/components/SettingsModalButton.vue
@@ -1,9 +1,9 @@
 <template>
-  <button class="settings-button" @click="settingsModalOpen = true">
+  <button class="settings-button" @click="this.showModal">
     <tapestry-icon icon="cog"></tapestry-icon>
     <settings-modal
       :show="settingsModalOpen"
-      @close="settingsModalOpen = false"
+      @close="this.closeModal"
     ></settings-modal>
   </button>
 </template>
@@ -22,6 +22,16 @@ export default {
       settingsModalOpen: false,
     }
   },
+  methods: {
+    showModal() {
+      console.log("settings wshow plz")
+      this.settingsModalOpen = true;
+    },
+    closeModal() {
+      console.log("settings close plz")
+      this.settingsModalOpen = false;
+    }
+  }
 }
 </script>
 

--- a/templates/vue/src/components/SettingsModalButton.vue
+++ b/templates/vue/src/components/SettingsModalButton.vue
@@ -24,11 +24,9 @@ export default {
   },
   methods: {
     showModal() {
-      console.log("settings wshow plz")
       this.settingsModalOpen = true;
     },
     closeModal() {
-      console.log("settings close plz")
       this.settingsModalOpen = false;
     }
   }


### PR DESCRIPTION
After opening the settings modal for the first time, subsequent clicks on the gear icon will not open the modal.
This rectifies that issue, as well as removing the error with mutating the 'show' prop directly that used to be bound to the b-modal visible state.