### PR TITLE
748 - Bug Fix: Node not displaying after changing connections

### DIFF
--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -531,8 +531,8 @@ class Tapestry implements ITapestry
         $queue->enqueue($from);
         while (!$queue->isEmpty()) {
             $node = $queue->dequeue();
-            if (TapestryCache::exists(__METHOD__, [$node, $to, $superuser_override, $userId])) {
-                return TapestryCache::get(__METHOD__, [$node, $to, $superuser_override, $userId]);
+            if (TapestryCache::get(__METHOD__, [$node, $to, $superuser_override, $userId])) {
+                return true;
             }
             if (TapestryHelpers::userIsAllowed('READ', $node, $this->postId, $superuser_override, $userId)
                 || (TapestryHelpers::userIsAllowed('ADD', $node, $this->postId, $superuser_override, $userId)

--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/../utilities/class.tapestry-cache.php';
 require_once dirname(__FILE__).'/../utilities/class.tapestry-errors.php';
 require_once dirname(__FILE__).'/../utilities/class.tapestry-helpers.php';
 require_once dirname(__FILE__).'/../utilities/class.tapestry-user-roles.php';


### PR DESCRIPTION
Closes #748 

Updates _pathIsAllowed implementation to use breadth-first-search. It only uses cached _pathIsAllowed when it returns true. Otherwise, if a node did not have permission to be read, the cache would return false before looking at other possible paths. 