### PR TITLE
775 - Update TapestryNode to use relative coordinates

### DIFF
--- a/templates/vue/src/components/TapestryNode.vue
+++ b/templates/vue/src/components/TapestryNode.vue
@@ -3,6 +3,7 @@
     <g
       v-show="show"
       ref="node"
+      :transform="`translate(${node.coordinates.x}, ${node.coordinates.y})`"
       :class="{ opaque: !visibleNodes.includes(node.id) }"
       :style="{
         cursor: node.accessible || hasPermission('edit') ? 'pointer' : 'not-allowed',
@@ -11,16 +12,9 @@
       @mouseover="handleMouseover"
       @mouseleave="$emit('mouseleave')"
     >
-      <circle
-        ref="circle"
-        :cx="node.coordinates.x"
-        :cy="node.coordinates.y"
-        :fill="fill"
-      ></circle>
+      <circle ref="circle" :fill="fill"></circle>
       <circle
         v-if="selected || !node.accessible"
-        :cx="node.coordinates.x"
-        :cy="node.coordinates.y"
         :r="radius"
         :fill="overlayFill"
         class="node-overlay"
@@ -31,8 +25,6 @@
             node.nodeType !== '' &&
             !node.hideProgress
         "
-        :x="node.coordinates.x"
-        :y="node.coordinates.y"
         :radius="radius"
         :progress="progress"
         :locked="!node.accessible"
@@ -43,8 +35,8 @@
           class="metaWrapper"
           :width="(140 * 2 * 5) / 6"
           :height="(140 * 2 * 5) / 6"
-          :x="node.coordinates.x - (140 * 5) / 6"
-          :y="node.coordinates.y - (140 * 5) / 6"
+          :x="-(140 * 5) / 6"
+          :y="-(140 * 5) / 6"
         >
           <div class="meta">
             <p class="title">{{ node.title }}</p>
@@ -55,8 +47,8 @@
           <foreignObject
             v-if="!node.hideMedia"
             class="node-button-wrapper"
-            :x="node.coordinates.x - 30"
-            :y="node.coordinates.y - radius - 30"
+            x="-30"
+            :y="-radius - 30"
           >
             <button
               class="node-button"
@@ -73,14 +65,14 @@
           <add-child-button
             v-if="hasPermission('add') && !isSubAccordionRow"
             :node="node"
-            :x="node.coordinates.x - 65"
-            :y="node.coordinates.y + radius - 30"
+            x="-65"
+            :y="radius - 30"
           ></add-child-button>
           <foreignObject
             v-if="hasPermission('edit')"
             class="node-button-wrapper"
-            :x="node.coordinates.x + 5"
-            :y="node.coordinates.y + radius - 30"
+            x="5"
+            :y="radius - 30"
           >
             <button class="node-button" @click.stop="editNode">
               <tapestry-icon icon="pen"></tapestry-icon>

--- a/templates/vue/src/components/tapestry-node/AddChildButton.vue
+++ b/templates/vue/src/components/tapestry-node/AddChildButton.vue
@@ -33,11 +33,11 @@ export default {
       required: true,
     },
     x: {
-      type: Number,
+      type: [String, Number],
       required: true,
     },
     y: {
-      type: Number,
+      type: [String, Number],
       required: true,
     },
   },

--- a/templates/vue/src/components/tapestry-node/ProgressBar.vue
+++ b/templates/vue/src/components/tapestry-node/ProgressBar.vue
@@ -3,17 +3,10 @@
     <circle
       ref="track"
       class="track"
-      :cx="x"
-      :cy="y"
       :stroke-width="width"
       :stroke="locked ? '#999' : 'currentColor'"
     ></circle>
-    <path
-      v-show="!locked && progress > 0"
-      ref="path"
-      class="bar"
-      :transform="`translate(${x}, ${y})`"
-    ></path>
+    <path v-show="!locked && progress > 0" ref="path" class="bar"></path>
   </g>
 </template>
 
@@ -32,14 +25,6 @@ export default {
       required: true,
     },
     radius: {
-      type: Number,
-      required: true,
-    },
-    x: {
-      type: Number,
-      required: true,
-    },
-    y: {
       type: Number,
       required: true,
     },


### PR DESCRIPTION
Closes #775 

Previously, the elements inside a TapestryNode component uses absolute coordinates read from the `node` object. This PR changes this so the node coordinates are only read once (as a transform), allowing the child components to use relative coordinates instead.

This change was necessary when migrating some TYDE components. I noticed it wasn't a TYDE-specific change so I introduced the same code over to master.