### PR TITLE
782 - Bug fix: Zero depth makes all nodes grandchild nodes

### DIFF
--- a/templates/vue/src/components/TapestryDepthSlider.vue
+++ b/templates/vue/src/components/TapestryDepthSlider.vue
@@ -116,6 +116,23 @@ export default {
     ...mapMutations(["updateNode"]),
     updateNodeTypes() {
       const depth = parseInt(this.currentDepth)
+
+      if (depth === 0) {
+        const nodesToUpdate = Object.values(this.nodes).filter(
+          node => node.nodeType !== "child"
+        )
+        nodesToUpdate.forEach(node => {
+          this.updateNode({
+            id: node.id,
+            newNode: {
+              nodeType: "child",
+            },
+          })
+        })
+        this.$emit("change")
+        return
+      }
+
       const updated = new Set()
       const nodesAtCurrentDepth = this.levels[depth]
       if (nodesAtCurrentDepth) {


### PR DESCRIPTION
Closes #782 

This PR fixes a bug where setting depth to zero in the url makes all nodes look like grandchild nodes. To test:

1. Create a Tapestry with a reasonable depth (> 3)
2. Change the depth query parameter in the url to `depth=0` (if it's not there, add `?depth=0` to the url)
3. All nodes should be visible and the same size (except the selected node, which as regular behaviour should be larger)