### PR TITLE
818 - admin private nodes are not hidden

### DIFF
--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -491,7 +491,6 @@ class Tapestry implements ITapestry
         if (!isset($tapestry->settings->superuserOverridePermissions)) {
             $tapestry->settings->superuserOverridePermissions = true;
         }
-
         $tapestry->nodes = $this->_filterNodesMetaIdsByStatus($tapestry->nodes);
 
         if ($tapestry->settings->superuserOverridePermissions && $roles->canEdit($this->postId)) {
@@ -499,8 +498,10 @@ class Tapestry implements ITapestry
 
             return $tapestry;
         } else {
-            $tapestry->nodes = $this->_filterNodeMetaIdsByPermissions($tapestry->rootId,
-                $tapestry->settings->superuserOverridePermissions, $filterUserId);
+            $nodesFilteredByStatus = $tapestry->nodes;
+
+            $tapestry->nodes = array_intersect($nodesFilteredByStatus, $this->_filterNodeMetaIdsByPermissions($tapestry->rootId,
+                $tapestry->settings->superuserOverridePermissions, $filterUserId));
 
             $tapestry->links = $this->_filterLinksByNodeMetaIds($tapestry->links, $tapestry->nodes);
             $tapestry->groups = TapestryHelpers::getGroupIdsOfUser(wp_get_current_user()->ID, $this->postId);
@@ -534,7 +535,6 @@ class Tapestry implements ITapestry
         $checked = [];
         $nodesPermitted = [];
         $this->_traverseNodes($rootId, $checked, $nodesPermitted, $superuser_override, $currentUserId, $secondaryUserId);
-
         return $nodesPermitted;
     }
 

--- a/config/php.conf.ini
+++ b/config/php.conf.ini
@@ -3,3 +3,5 @@ memory_limit = 64M
 upload_max_filesize = 64M
 post_max_size = 64M
 max_execution_time = 600
+log_errors = On
+error_log = /dev/stderr

--- a/templates/vue/src/utils/dataset.js
+++ b/templates/vue/src/utils/dataset.js
@@ -5,6 +5,8 @@ export function parse(dataset) {
     ...dataset,
   }
 
+  if (!Array.isArray(dataset.nod)) dataset.nodes = Object.values(dataset.nodes)
+
   for (const node of dataset.nodes) {
     const { imageURL, lockedImageURL } = node
     const { mediaURL } = node.typeData

--- a/templates/vue/src/utils/dataset.js
+++ b/templates/vue/src/utils/dataset.js
@@ -5,7 +5,7 @@ export function parse(dataset) {
     ...dataset,
   }
 
-  if (!Array.isArray(dataset.nod)) dataset.nodes = Object.values(dataset.nodes)
+  if (!Array.isArray(dataset.nodes)) dataset.nodes = Object.values(dataset.nodes)
 
   for (const node of dataset.nodes) {
     const { imageURL, lockedImageURL } = node


### PR DESCRIPTION
Closes #818 

Makes sure to not override the status filtered node result with the permissions filtered node result when not using superUser override, instead, we use their intersection