### PR TITLE
894 - Prompt user when exiting Node Modal with unsaved changes

### DIFF
--- a/templates/vue/cypress/fixtures/accordion.json
+++ b/templates/vue/cypress/fixtures/accordion.json
@@ -59,9 +59,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -141,9 +138,6 @@
           "read"
         ],
         "subscriber": [
-          "read"
-        ],
-        "copilot": [
           "read"
         ]
       },

--- a/templates/vue/cypress/fixtures/one-node.json
+++ b/templates/vue/cypress/fixtures/one-node.json
@@ -59,9 +59,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -82,8 +79,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 0,
       "x": 2939.49951171875,
@@ -93,7 +89,18 @@
       "nodeType": "root",
       "unlocked": true,
       "depth": 0,
-      "accessible": true
+      "accessible": true,
+      "license": {
+        "name": "CC-BY-SA",
+        "icons": [
+          "fab fa-creative-commons",
+          "fab fa-creative-commons-by",
+          "fab fa-creative-commons-sa"
+        ],
+        "type": "cc",
+        "link": "",
+        "description": ""
+      }
     }
   ],
   "links": [],

--- a/templates/vue/cypress/fixtures/three-nodes.json
+++ b/templates/vue/cypress/fixtures/three-nodes.json
@@ -59,9 +59,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -139,9 +136,6 @@
           "read"
         ],
         "subscriber": [
-          "read"
-        ],
-        "copilot": [
           "read"
         ]
       },

--- a/templates/vue/cypress/fixtures/two-nodes.json
+++ b/templates/vue/cypress/fixtures/two-nodes.json
@@ -59,9 +59,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -82,8 +79,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 0,
       "x": 2939.49951171875,
@@ -154,9 +150,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -177,8 +170,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 1,
       "x": 3500.967041015625,

--- a/templates/vue/cypress/fixtures/user.json
+++ b/templates/vue/cypress/fixtures/user.json
@@ -64,9 +64,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -87,8 +84,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 0,
       "x": 1075.8989562988281,
@@ -177,9 +173,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -210,8 +203,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 1,
       "x": 1332.3216552734375,
@@ -281,9 +273,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -304,8 +293,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 2,
       "x": 488.66986083984375,
@@ -373,9 +361,6 @@
           "read"
         ],
         "subscriber": [
-          "read"
-        ],
-        "copilot": [
           "read"
         ]
       },
@@ -686,8 +671,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 3,
       "x": 301.1390256881714,
@@ -756,9 +740,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -815,8 +796,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 4,
       "x": 728.9745178222656,
@@ -885,9 +865,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -908,8 +885,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 5,
       "x": 862.9227905273438,
@@ -983,9 +959,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -1006,8 +979,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 6,
       "x": 257.38909912109375,
@@ -1077,9 +1049,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -1101,8 +1070,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 7,
       "x": 1802.8187255859375,
@@ -1172,9 +1140,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -1196,8 +1161,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 8,
       "x": 1642.0430908203125,
@@ -1266,9 +1230,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -1290,8 +1251,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 9,
       "x": 1324.94287109375,
@@ -1361,9 +1321,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -1385,8 +1342,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 10,
       "x": 1790.173095703125,
@@ -1454,9 +1410,6 @@
           "read"
         ],
         "subscriber": [
-          "read"
-        ],
-        "copilot": [
           "read"
         ]
       },
@@ -1710,8 +1663,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 11,
       "x": 1042.5700073242188,
@@ -1781,9 +1733,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -1804,8 +1753,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 12,
       "x": 520.9402160644531,
@@ -1877,9 +1825,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -1900,8 +1845,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 13,
       "x": 799.778564453125,
@@ -1971,9 +1915,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -1994,8 +1935,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 14,
       "x": 1534.2563171386719,
@@ -2061,9 +2001,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -2084,8 +2021,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 15,
       "x": 2007.7608337402344,

--- a/templates/vue/cypress/integration/node-authoring.spec.js
+++ b/templates/vue/cypress/integration/node-authoring.spec.js
@@ -170,10 +170,11 @@ describe("Node Authoring", () => {
 
         // check that error persists
         cy.getByTestId("submit-node-modal").click()
-        cy.contains(videoErrorMsg).should("exist")
+        cy.contains(videoErrorMsg, { timeout: 10000 }).should("exist")
 
         // check that node is not created
         cy.contains(/cancel/i).click()
+        cy.contains(/close/i).click()
         cy.contains(`/${nodeName}/i`).should("not.exist")
 
         // check that error does not persist to new creation
@@ -231,6 +232,7 @@ describe("Node Authoring", () => {
 
         // check that node is not created
         cy.contains(/cancel/i).click()
+        cy.contains(/close/i).click()
         cy.contains(`/${nodeName}/i`).should("not.exist")
       })
     })

--- a/templates/vue/cypress/integration/node-operations.spec.js
+++ b/templates/vue/cypress/integration/node-operations.spec.js
@@ -13,6 +13,7 @@ describe("Node Operations", () => {
       cy.openModal("add", id)
       cy.getByTestId("node-modal").should("be.visible")
       cy.contains(/cancel/i).click()
+      cy.contains(/close/i).click()
       cy.getByTestId("node-modal").should("not.be.visible")
 
       cy.openModal("edit", id)
@@ -35,36 +36,27 @@ describe("Node Operations", () => {
   })
 
   it("should prompt user if closing modal with changes", () => {
-
     cy.getSelectedNode().then(node => {
       cy.openModal("edit", node.id)
-      cy.getByTestId("node-modal").should("be.visible")
+      cy.getByTestId("node-modal").should("exist")
 
       cy.getByTestId("node-title").type(node.title)
 
       clickOutsideModal()
-      cy.getByTestId("node-modal").should("be.visible")
-      cy.getByTestId("node-modal-confirmation").should("be.visible")
+      cy.getByTestId("node-modal").should("exist")
+      cy.get(".node-modal-confirmation").should("be.visible")
 
-      cy.getByTestId("node-modal-confirmation-yes").click()
+      cy.get(".node-modal-confirmation").contains("Cancel").click()
       cy.getByTestId("node-modal").should("be.visible")
-      cy.getByTestId("node-modal-confirmation").should("not.be.visible")
+      cy.get(".node-modal-confirmation").should("not.be.visible")
 
       cy.get(".close").click()
-      cy.getByTestId("node-modal").should("be.visible")
-      cy.getByTestId("node-modal-confirmation").should("be.visible")
+      cy.getByTestId("node-modal").should("exist")
+      cy.get(".node-modal-confirmation").should("be.visible")
 
-      cy.getByTestId("node-modal-confirmation-no").click()
+      cy.get(".node-modal-confirmation").contains("Close").click()
       cy.getByTestId("node-modal").should("not.be.visible")
-      cy.getByTestId("node-modal-confirmation").should("not.be.visible")
-    })
-
-    cy.getSelectedNode().then(node => {
-      cy.openModal("edit", node.id)
-      cy.getByTestId("node-modal").should("be.visible")
-
-      clickOutsideModal()
-      cy.getByTestId("node-modal").should("not.be.visible")
+      cy.get(".node-modal-confirmation").should("not.be.visible")
     })
   })
 

--- a/templates/vue/cypress/integration/node-operations.spec.js
+++ b/templates/vue/cypress/integration/node-operations.spec.js
@@ -1,3 +1,7 @@
+const clickOutsideModal = () => {
+  cy.get("#node-modal").click("topLeft")
+}
+
 describe("Node Operations", () => {
   beforeEach(() => {
     cy.fixture("one-node.json").as("oneNode")
@@ -27,6 +31,58 @@ describe("Node Operations", () => {
       })
       cy.getNodeById(node.id).click()
       cy.lightbox().should("be.visible")
+    })
+  })
+
+  it("should prompt user if closing modal with changes", () => {
+
+    cy.getSelectedNode().then(node => {
+      cy.openModal("edit", node.id)
+      cy.getByTestId("node-modal").should("be.visible")
+
+      cy.getByTestId("node-title").type(node.title)
+
+      clickOutsideModal()
+      cy.getByTestId("node-modal").should("be.visible")
+      cy.getByTestId("node-modal-confirmation").should("be.visible")
+
+      cy.getByTestId("node-modal-confirmation-yes").click()
+      cy.getByTestId("node-modal").should("be.visible")
+      cy.getByTestId("node-modal-confirmation").should("not.be.visible")
+
+      cy.get(".close").click()
+      cy.getByTestId("node-modal").should("be.visible")
+      cy.getByTestId("node-modal-confirmation").should("be.visible")
+
+      cy.getByTestId("node-modal-confirmation-no").click()
+      cy.getByTestId("node-modal").should("not.be.visible")
+      cy.getByTestId("node-modal-confirmation").should("not.be.visible")
+    })
+
+    cy.getSelectedNode().then(node => {
+      cy.openModal("edit", node.id)
+      cy.getByTestId("node-modal").should("be.visible")
+
+      clickOutsideModal()
+      cy.getByTestId("node-modal").should("not.be.visible")
+    })
+  })
+
+  it("should not prompt user if closing modal without changes", () => {
+    cy.getSelectedNode().then(node => {
+      cy.openModal("edit", node.id)
+      cy.getByTestId("node-modal").should("be.visible")
+
+      cy.get(".close").click()
+      cy.getByTestId("node-modal").should("not.be.visible")
+    })
+
+    cy.getSelectedNode().then(node => {
+      cy.openModal("edit", node.id)
+      cy.getByTestId("node-modal").should("be.visible")
+
+      clickOutsideModal()
+      cy.getByTestId("node-modal").should("not.be.visible")
     })
   })
 })

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -533,15 +533,17 @@ export default {
     handleClose(event) {
       const oldNode = this.getNode(this.nodeId)
       if (
-        !Helpers.nodeEqual(oldNode, this.node) &&
+        (this.type === "add" ||
+          !Helpers.nodeEqual(oldNode, this.node, ["license", "permissions"])) &&
         (event.trigger == "backdrop" ||
           event.trigger == "headerclose" ||
           event.trigger == "esc" ||
-          event instanceof MouseEvent) // cancel
+          event instanceof MouseEvent) // cancel triggered
       ) {
         event.preventDefault()
         this.$bvModal
           .msgBoxConfirm("All unsaved changes will be lost.", {
+            modalClass: "node-modal-confirmation",
             title: "Are you sure you want to continue?",
             okTitle: "Close",
           })

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -137,7 +137,7 @@
               size="sm"
               variant="light"
               :disabled="loading || fileUploading"
-              @click="close"
+              @click="handleClose"
             >
               Cancel
             </b-button>
@@ -536,7 +536,8 @@ export default {
         !Helpers.nodeEqual(oldNode, this.node) &&
         (event.trigger == "backdrop" ||
           event.trigger == "headerclose" ||
-          event.trigger == "esc")
+          event.trigger == "esc" ||
+          event instanceof MouseEvent) // cancel
       ) {
         event.preventDefault()
         this.$bvModal

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -556,8 +556,7 @@ export default {
     handleClose(event) {
       const oldNode = this.getNode(this.nodeId)
       if (
-        (this.type === "add" ||
-          !Helpers.nodeEqual(oldNode, this.node, ["license", "permissions"])) &&
+        (this.type === "add" || !Helpers.nodeEqual(oldNode, this.node)) &&
         (event.trigger == "backdrop" ||
           event.trigger == "headerclose" ||
           event.trigger == "esc" ||

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -8,9 +8,7 @@
     class="text-muted"
     scrollable
     body-class="p-0"
-    no-close-on-esc
-    no-close-on-backdrop
-    @close="handleClose"
+    @hide="handleClose"
   >
     <div v-if="formErrors.length" class="modal-header-row">
       <b-alert id="tapestry-modal-form-errors" variant="danger" show>
@@ -533,16 +531,21 @@ export default {
       }
     },
     handleClose(event) {
-      event.preventDefault()
-      this.$bvModal
-        .msgBoxConfirm("Are you sure?")
-        .then(close => {
-          if (close) {
-            this.close()
-            return true
-          }
-        })
-        .catch(err => console.log(err))
+      if (
+        event.trigger == "backdrop" ||
+        event.trigger == "headerclose" ||
+        event.trigger == "esc"
+      ) {
+        event.preventDefault()
+        this.$bvModal
+          .msgBoxConfirm("Are you sure?")
+          .then(close => {
+            if (close) {
+              this.close()
+            }
+          })
+          .catch(err => console.log(err))
+      }
     },
     close() {
       if (this.show) {

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -277,6 +277,7 @@ export default {
       loadDuration: false,
       warningText: "",
       deleteWarningText: "",
+      formUpdated: false,
     }
   },
   computed: {
@@ -532,9 +533,10 @@ export default {
     },
     handleClose(event) {
       if (
-        event.trigger == "backdrop" ||
-        event.trigger == "headerclose" ||
-        event.trigger == "esc"
+        this.formUpdated &&
+        (event.trigger == "backdrop" ||
+          event.trigger == "headerclose" ||
+          event.trigger == "esc")
       ) {
         event.preventDefault()
         this.$bvModal
@@ -545,6 +547,8 @@ export default {
             }
           })
           .catch(err => console.log(err))
+      } else {
+        this.close()
       }
     },
     close() {

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -541,7 +541,10 @@ export default {
       ) {
         event.preventDefault()
         this.$bvModal
-          .msgBoxConfirm("Are you sure?")
+          .msgBoxConfirm("All unsaved changes will be lost.", {
+            title: "Are you sure you want to continue?",
+            okTitle: "Close",
+          })
           .then(close => {
             if (close) {
               this.close()

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -8,7 +8,9 @@
     class="text-muted"
     scrollable
     body-class="p-0"
-    @hidden="close"
+    no-close-on-esc
+    no-close-on-backdrop
+    @close="handleClose"
   >
     <div v-if="formErrors.length" class="modal-header-row">
       <b-alert id="tapestry-modal-form-errors" variant="danger" show>
@@ -529,6 +531,18 @@ export default {
           query: this.$route.query,
         })
       }
+    },
+    handleClose(event) {
+      event.preventDefault()
+      this.$bvModal
+        .msgBoxConfirm("Are you sure?")
+        .then(close => {
+          if (close) {
+            this.close()
+            return true
+          }
+        })
+        .catch(err => console.log(err))
     },
     close() {
       if (this.show) {

--- a/templates/vue/src/components/NodeModal.vue
+++ b/templates/vue/src/components/NodeModal.vue
@@ -277,7 +277,6 @@ export default {
       loadDuration: false,
       warningText: "",
       deleteWarningText: "",
-      formUpdated: false,
     }
   },
   computed: {
@@ -532,8 +531,9 @@ export default {
       }
     },
     handleClose(event) {
+      const oldNode = this.getNode(this.nodeId)
       if (
-        this.formUpdated &&
+        !Helpers.nodeEqual(oldNode, this.node) &&
         (event.trigger == "backdrop" ||
           event.trigger == "headerclose" ||
           event.trigger == "esc")

--- a/templates/vue/src/fixtures/one-node.json
+++ b/templates/vue/src/fixtures/one-node.json
@@ -59,9 +59,6 @@
         ],
         "subscriber": [
           "read"
-        ],
-        "copilot": [
-          "read"
         ]
       },
       "hideTitle": false,
@@ -82,8 +79,7 @@
         "public",
         "authenticated",
         "contributor",
-        "subscriber",
-        "copilot"
+        "subscriber"
       ],
       "index": 0,
       "x": 2939.49951171875,

--- a/templates/vue/src/utils/Helpers.js
+++ b/templates/vue/src/utils/Helpers.js
@@ -115,6 +115,36 @@ export default class Helpers {
   }
 
   /**
+   * Deeply checks if two nodes are different from one another
+   * - Allows missing property as long as loosely equals null
+   * Source: https://stackoverflow.com/questions/25456013/javascript-deepequal-comparison/25456134
+   * @param {Object} src
+   * @param {Object} other
+   */
+  static nodeEqual(src, other) {
+    if (src === other) {
+      return true
+    } else if (
+      typeof src == "object" &&
+      src != null &&
+      typeof other == "object" &&
+      other != null
+    ) {
+      for (var prop in src) {
+        if (other.hasOwnProperty(prop)) {
+          if (!Helpers.nodeEqual(src[prop], other[prop])) return false
+        } else {
+          // If property does not exist, check if null or false
+          if (src[prop] != 0) return false
+        }
+      }
+      return true
+    } else {
+      return false
+    }
+  }
+
+  /**
    * Returns a deep copy of a given object.
    * Source: https://medium.com/javascript-in-plain-english/how-to-deep-copy-objects-and-arrays-in-javascript-7c911359b089
    * @param {Object | Array} obj

--- a/templates/vue/src/utils/Helpers.js
+++ b/templates/vue/src/utils/Helpers.js
@@ -115,7 +115,7 @@ export default class Helpers {
   }
 
   /**
-   * Deeply checks if two nodes are different from one another
+   * Checks if two nodes are equal to each other
    * - Allows missing property as long as loosely equals null
    * Source: https://stackoverflow.com/questions/25456013/javascript-deepequal-comparison/25456134
    * @param {Object} src
@@ -139,9 +139,28 @@ export default class Helpers {
         }
       }
       return true
+    } else if (Array.isArray(src) && Array.isArray(other)) {
+      return Helpers.arraysEqual(src, other)
     } else {
       return false
     }
+  }
+
+  /**
+   * Checks if two arrays are equal to each other
+   * Source: https://stackoverflow.com/questions/3115982/how-to-check-if-two-arrays-are-equal-with-javascript
+   * @param {Object} a
+   * @param {Object} b
+   */
+  static arraysEqual(a, b) {
+    if (a === b) return true;
+    if (a == null || b == null) return false;
+    if (a.length !== b.length) return false;
+
+    for (var i = 0; i < a.length; ++i) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
   }
 
   /**

--- a/templates/vue/src/utils/Helpers.js
+++ b/templates/vue/src/utils/Helpers.js
@@ -117,48 +117,41 @@ export default class Helpers {
   /**
    * Checks if two nodes are equal to each other
    * - Allows missing property as long as loosely equals null
-   * Source: https://stackoverflow.com/questions/25456013/javascript-deepequal-comparison/25456134
+   * Reference: https://stackoverflow.com/questions/25456013/javascript-deepequal-comparison/25456134
    * @param {Object} src
    * @param {Object} other
+   * @param {Array} ignoreProps
    */
-  static nodeEqual(src, other) {
+  static nodeEqual(src, other, ignoreProps = []) {
     if (src === other) {
       return true
     } else if (Array.isArray(src) && Array.isArray(other)) {
-      return Helpers.arraysEqual(src, other)
+      if (src.length !== other.length) return false
+
+      for (let i = 0; i < src.length; i++) {
+        if (!Helpers.nodeEqual(src[i], other[i])) return false
+      }
     } else if (
       typeof src == "object" &&
       src != null &&
       typeof other == "object" &&
       other != null
     ) {
-      for (var prop in src) {
+      for (let prop in src) {
+        if (ignoreProps.includes(prop)) continue
         if (other.hasOwnProperty(prop)) {
-          if (!Helpers.nodeEqual(src[prop], other[prop])) return false
+          if (!Helpers.nodeEqual(src[prop], other[prop])) {
+            return false
+          }
         } else {
           // If property does not exist, check if null or false
-          if (src[prop] != 0) return false
+          if (src[prop] != 0) {
+            return false
+          }
         }
       }
-      return true
     } else {
       return false
-    }
-  }
-
-  /**
-   * Checks if two arrays are equal to each other
-   * Source: https://stackoverflow.com/questions/3115982/how-to-check-if-two-arrays-are-equal-with-javascript
-   * @param {Object} a
-   * @param {Object} b
-   */
-  static arraysEqual(a, b) {
-    if (a === b) return true
-    if (a == null || b == null) return false
-    if (a.length !== b.length) return false
-
-    for (var i = 0; i < a.length; ++i) {
-      if (a[i] !== b[i]) return false
     }
     return true
   }

--- a/templates/vue/src/utils/Helpers.js
+++ b/templates/vue/src/utils/Helpers.js
@@ -124,6 +124,8 @@ export default class Helpers {
   static nodeEqual(src, other) {
     if (src === other) {
       return true
+    } else if (Array.isArray(src) && Array.isArray(other)) {
+      return Helpers.arraysEqual(src, other)
     } else if (
       typeof src == "object" &&
       src != null &&
@@ -139,8 +141,6 @@ export default class Helpers {
         }
       }
       return true
-    } else if (Array.isArray(src) && Array.isArray(other)) {
-      return Helpers.arraysEqual(src, other)
     } else {
       return false
     }
@@ -153,14 +153,14 @@ export default class Helpers {
    * @param {Object} b
    */
   static arraysEqual(a, b) {
-    if (a === b) return true;
-    if (a == null || b == null) return false;
-    if (a.length !== b.length) return false;
+    if (a === b) return true
+    if (a == null || b == null) return false
+    if (a.length !== b.length) return false
 
     for (var i = 0; i < a.length; ++i) {
-      if (a[i] !== b[i]) return false;
+      if (a[i] !== b[i]) return false
     }
-    return true;
+    return true
   }
 
   /**


### PR DESCRIPTION
## Changes
* Add confirmation modal to prompt users when exiting Node Modal with unsaved changes
    * Assumes that there are always changes when if adding node
    * Ignores changes in permissions and license
        * This can be changed but test fixtures will need to be updated to remove copilot and update license
## Screenshot
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/45089842/101994181-343a2c80-3c75-11eb-9424-8daa5ae16452.gif)
## Issue Linkage
Closes #894 
## PR Dependency
Depends on: N/A
## Automated Testing
* Should prompt user if closing modal with changes
* Should not prompt user if closing modal without changes
