### PR TITLE
899 - Bug Fix: Background for tapestries do not load after refresh

### DIFF
--- a/templates/vue/cypress/integration/settings.spec.js
+++ b/templates/vue/cypress/integration/settings.spec.js
@@ -38,7 +38,7 @@ describe("Settings", () => {
       .then(url => {
         cy.getByTestId("node-upload-input").should("have.value", url)
         cy.submitSettingsModal()
-        cy.get("#vue-app").should("have.css", "background-image", `url("${url}")`)
+        cy.get("body").should("have.css", "background-image", `url("${url}")`)
       })
   })
 

--- a/templates/vue/cypress/integration/settings.spec.js
+++ b/templates/vue/cypress/integration/settings.spec.js
@@ -38,7 +38,7 @@ describe("Settings", () => {
       .then(url => {
         cy.getByTestId("node-upload-input").should("have.value", url)
         cy.submitSettingsModal()
-        cy.get("#app").should("have.css", "background-image", `url("${url}")`)
+        cy.get("#vue-app").should("have.css", "background-image", `url("${url}")`)
       })
   })
 

--- a/templates/vue/src/App.vue
+++ b/templates/vue/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div id="vue-app">
     <loading v-if="loading" style="height: 75vh;"></loading>
     <div v-else id="app">
       <tapestry-app></tapestry-app>

--- a/templates/vue/src/App.vue
+++ b/templates/vue/src/App.vue
@@ -1,13 +1,11 @@
 <template>
-  <div id="vue-app">
-    <loading v-if="loading" style="height: 75vh;"></loading>
-    <div v-else id="app">
-      <tapestry-app></tapestry-app>
-      <router-view name="lightbox"></router-view>
-      <node-modal></node-modal>
-      <tapestry-sidebar v-if="!isEmpty"></tapestry-sidebar>
-      <tapestry-error></tapestry-error>
-    </div>
+  <loading v-if="loading" style="height: 75vh;"></loading>
+  <div v-else id="app">
+    <tapestry-app></tapestry-app>
+    <router-view name="lightbox"></router-view>
+    <node-modal></node-modal>
+    <tapestry-sidebar v-if="!isEmpty"></tapestry-sidebar>
+    <tapestry-error></tapestry-error>
   </div>
 </template>
 

--- a/templates/vue/src/App.vue
+++ b/templates/vue/src/App.vue
@@ -1,11 +1,13 @@
 <template>
-  <loading v-if="loading" style="height: 75vh;"></loading>
-  <div v-else id="app">
-    <tapestry-app></tapestry-app>
-    <router-view name="lightbox"></router-view>
-    <node-modal></node-modal>
-    <tapestry-sidebar v-if="!isEmpty"></tapestry-sidebar>
-    <tapestry-error></tapestry-error>
+  <div>
+    <loading v-if="loading" style="height: 75vh;"></loading>
+    <div v-else id="app">
+      <tapestry-app></tapestry-app>
+      <router-view name="lightbox"></router-view>
+      <node-modal></node-modal>
+      <tapestry-sidebar v-if="!isEmpty"></tapestry-sidebar>
+      <tapestry-error></tapestry-error>
+    </div>
   </div>
 </template>
 

--- a/templates/vue/src/components/TapestryApp.vue
+++ b/templates/vue/src/components/TapestryApp.vue
@@ -131,8 +131,7 @@ export default {
     background: {
       immediate: true,
       handler(background) {
-        const app = this.$root.$el
-        app.style.backgroundImage = background ? `url(${background})` : ""
+        document.body.style.backgroundImage = background ? `url(${background})` : ""
       },
     },
     selectedId: {


### PR DESCRIPTION
## Changes
* Add wrapper around app to house background image.
    * The issue was that the TapestryApp background handler was taking the first element and applying the URL to it. The first element was the loader which would later disappear, thus, missing background image.
## Issue Linkage
Closes #899 
## PR Dependency
Depends on: N/A
## Automated Testing
N/A