### PR TITLE
919 - TYDE CoS #2 - Add CoS endpoints

### DIFF
--- a/classes/activities/class.circle-of-support.php
+++ b/classes/activities/class.circle-of-support.php
@@ -1,0 +1,58 @@
+<?php
+
+class CircleOfSupport
+{
+    private $userId;
+    private $versions;
+
+    const META_KEY = 'circle_of_support';
+
+    public function __construct($userId = 0)
+    {
+        $this->userId = $userId || wp_get_current_user()->ID;
+        $this->versions = $this->_getVersions();
+    }
+
+    public function get($date = 0)
+    {
+        if ($date) {
+            foreach ($this->versions as $version) {
+                if ($this->_isSameDay($version->timestamp, $date)) {
+                    return $version;
+                }
+            }
+
+            return null;
+        }
+
+        return $this->versions[count($this->versions) - 1];
+    }
+
+    public function save($circleOfSupport)
+    {
+        $latest = $this->get();
+
+        if ($this->_isSameDay($latest->timestamp, $circleOfSupport->timestamp)) {
+            $this->versions[count($this->versions) - 1] = $circleOfSupport;
+        } else {
+            array_push($this->versions, $circleOfSupport);
+        }
+
+        update_user_meta($this->userId, CircleOfSupport::META_KEY, $this->versions);
+    }
+
+    private function _getVersions()
+    {
+        $versions = get_user_meta($this->userId, CircleOfSupport::META_KEY);
+        if (!is_array($versions)) {
+            return [];
+        }
+
+        return $versions;
+    }
+
+    private function _isSameDay($date1, $date2)
+    {
+        return date_format(new DateTime($date1), 'Ymd') == date_format(new DateTime($date2), 'Ymd');
+    }
+}

--- a/classes/activities/class.circle-of-support.php
+++ b/classes/activities/class.circle-of-support.php
@@ -5,7 +5,7 @@ class CircleOfSupport
     private $userId;
     private $versions;
 
-    const META_KEY = 'circle_of_support';
+    const META_KEY = 'tyde_circle_of_support';
 
     public function __construct($userId = 0)
     {

--- a/endpoints.php
+++ b/endpoints.php
@@ -11,6 +11,7 @@ require_once __DIR__.'/classes/class.tapestry-user-progress.php';
 require_once __DIR__.'/classes/class.tapestry-audio.php';
 require_once __DIR__.'/classes/class.tapestry-form.php';
 require_once __DIR__.'/classes/class.tapestry-h5p.php';
+require_once __DIR__.'/classes/activities/class.circle-of-support.php';
 require_once __DIR__.'/utilities/class.tapestry-user-roles.php';
 
 $REST_API_NAMESPACE = 'tapestry-tool/v1';
@@ -299,6 +300,20 @@ $REST_API_ENDPOINTS = [
             'callback' => 'get_all_user_roles',
         ],
     ],
+    'GET_CIRCLE_OF_SUPPORT' => (object) [
+        'ROUTE' => '/activities/cos',
+        'ARGUMENTS' => [
+            'methods' => $REST_API_GET_METHOD,
+            'callback' => 'getCircleOfSupport',
+        ]
+    ],
+    'POST_CIRCLE_OF_SUPPORT' => (object) [
+        'ROUTE' => '/activities/cos',
+        'ARGUMENTS' => [
+            'methods' => $REST_API_POST_METHOD,
+            'callback' => 'postCircleOfSupport'
+        ]
+    ]
 ];
 
 /*
@@ -1384,4 +1399,16 @@ function getTapestryContributors($request)
     } catch (TapestryError $e) {
         return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
     }
+}
+
+function getCircleOfSupport($request)
+{
+    $cos = new CircleOfSupport();
+    return $cos->get();
+}
+
+function postCircleOfSupport($request)
+{
+    $cos = new CircleOfSupport();
+    return $cos->save($request->get_body());
 }

--- a/templates/vue/src/components/TapestryApp.vue
+++ b/templates/vue/src/components/TapestryApp.vue
@@ -51,6 +51,7 @@
         ></locked-tooltip>
       </svg>
     </main>
+    <circle-of-support />
   </div>
 </template>
 
@@ -66,6 +67,7 @@ import LockedTooltip from "@/components/LockedTooltip"
 import TapestryFilter from "@/components/TapestryFilter"
 import Helpers from "@/utils/Helpers"
 import { names } from "@/config/routes"
+import CircleOfSupport from "./tyde/activities/CircleOfSupport"
 import * as wp from "@/services/wp"
 
 export default {
@@ -77,6 +79,7 @@ export default {
     SettingsModalButton,
     RootNodeButton,
     LockedTooltip,
+    CircleOfSupport,
   },
   data() {
     return {

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
@@ -20,7 +20,10 @@ export default {
     }
   },
   async mounted() {
-    this.cos = await client.getCosActivity()
+    const latestCosVersion = await client.getCosActivity()
+    if (latestCosVersion) {
+      this.cos = latestCosVersion
+    }
   },
 }
 </script>

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
@@ -18,9 +18,7 @@ export default {
     }
   },
   async mounted() {
-    await client.saveCosActivity(this.cos)
-    const cos = await client.getCosActivity()
-    console.log(cos)
+    this.cos = await client.getCosActivity()
   },
 }
 </script>

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
@@ -3,13 +3,24 @@
 </template>
 
 <script>
+import client from "@/services/TapestryAPI"
+
 export default {
   data() {
     return {
-      circles: [],
-      communities: [],
-      connections: [],
+      cos: {
+        id: "",
+        circles: [],
+        communities: [],
+        connections: [],
+        members: {},
+      },
     }
+  },
+  async mounted() {
+    await client.saveCosActivity(this.cos)
+    const cos = await client.getCosActivity()
+    console.log(cos)
   },
 }
 </script>

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
@@ -3,6 +3,7 @@
 </template>
 
 <script>
+import moment from "moment-timezone"
 import client from "@/services/TapestryAPI"
 
 export default {
@@ -14,6 +15,7 @@ export default {
         communities: [],
         connections: [],
         members: {},
+        timestamp: moment(),
       },
     }
   },

--- a/templates/vue/src/services/TapestryAPI.js
+++ b/templates/vue/src/services/TapestryAPI.js
@@ -273,6 +273,16 @@ class TapestryApi {
     // Send the event to an AJAX URL to be saved
     await axios.post(analyticsAJAXUrl, data)
   }
+
+  getCosActivity() {
+    return axios.get(`${apiUrl}/activities/cos`).then(res => res.data)
+  }
+
+  saveCosActivity(circleOfSupport) {
+    return axios
+      .post(`${apiUrl}/activities/cos`, circleOfSupport)
+      .then(res => res.data)
+  }
 }
 
 export default new TapestryApi(postId)


### PR DESCRIPTION
## Changes
* Adds a new **`/activities/cos`** endpoint for reading and saving CoS data, which is kept in the user's `usermeta` table.
* CoS data is versioned by day and is checked on a per-request basis.
* Adds a new **`CircleOfSupport`** class that handles reading and saving logic. Currently only has two public methods **`get()`** and **`save($circleOfSupport)`**.

## Screenshot
N/A

## Issue Linkage
Closes #919

## PR Dependency
Depends on: (PR # or N/A)

## Automated Testing
N/A
