### PR TITLE
934 - Add option in settings to show green halo around accepted nodes

### DIFF
--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -425,6 +425,7 @@ class Tapestry implements ITapestry
 
         $settings->showAccess = true;
         $settings->showRejected = false;
+        $settings->showAcceptedHighlight = true;
         $settings->defaultPermissions = TapestryNodePermissions::getDefaultNodePermissions($this->postId);
         $settings->superuserOverridePermissions = true;
         $settings->permalink = get_permalink($this->postId);

--- a/templates/vue/src/components/TapestryMain/TapestryNode.spec.js
+++ b/templates/vue/src/components/TapestryMain/TapestryNode.spec.js
@@ -1,0 +1,38 @@
+import { render } from "@/utils/test"
+
+import oneNodeTapestry from "@/fixtures/one-node.json"
+import TapestryNode from "./TapestryNode"
+import { nodeStatus } from "@/utils/constants"
+
+const node = oneNodeTapestry.nodes[0]
+node.reviewStatus = nodeStatus.ACCEPT
+node.status = nodeStatus.PUBLISH
+
+describe("Tapestry node", () => {
+  describe.only("Accepted nodes", () => {
+    const renderAcceptedNode = (settings = {}) => {
+      return render(TapestryNode, {
+        fixture: oneNodeTapestry,
+        props: {
+          node: node,
+          root: true,
+        },
+        settings: settings,
+      })
+    }
+
+    it("should render status bar when settings enabled", async () => {
+      const screen = renderAcceptedNode({ showAcceptedHighlight: true })
+      const statusBarCircle = screen.getByTestId(`node-status-${node.id}`)
+        .firstElementChild
+      expect(statusBarCircle).toHaveAttribute("stroke", "#5CE601")
+    })
+
+    it("should not render status bar when settings disabled", async () => {
+      const screen = renderAcceptedNode({ showAcceptedHighlight: false })
+      const statusBarCircle = screen.getByTestId(`node-status-${node.id}`)
+        .firstElementChild
+      expect(statusBarCircle).toHaveAttribute("stroke", "none")
+    })
+  })
+})

--- a/templates/vue/src/components/TapestryMain/TapestryNode/StatusBar.vue
+++ b/templates/vue/src/components/TapestryMain/TapestryNode/StatusBar.vue
@@ -41,6 +41,11 @@ export default {
       required: false,
       default: "",
     },
+    enableHighlight: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
   },
   computed: {
     width() {
@@ -59,6 +64,7 @@ export default {
           case nodeStatus.SUBMIT:
             return "#FFC107"
           case nodeStatus.ACCEPT:
+            if (!this.enableHighlight) return "none"
             return "#5CE601"
           case nodeStatus.REJECT:
             return "#CC444B"

--- a/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
+++ b/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
@@ -53,6 +53,8 @@
         :locked="!node.accessible"
         :status="node.status"
         :reviewStatus="node.reviewStatus"
+        :enableHighlight="highlightNode"
+        :data-qa="`node-status-${node.id}`"
       ></status-bar>
       <g v-show="node.nodeType !== 'grandchild' && node.nodeType !== ''">
         <transition name="fade">
@@ -281,6 +283,12 @@ export default {
         .map(this.getNode)
         .filter(n => n.status !== "draft")
       return rows.filter(row => row.completed).length / rows.length
+    },
+    highlightNode() {
+      return (
+        this.node.reviewStatus !== nodeStatus.ACCEPT ||
+        this.settings.showAcceptedHighlight
+      )
     },
   },
   watch: {

--- a/templates/vue/src/components/modals/SettingsModal/index.vue
+++ b/templates/vue/src/components/modals/SettingsModal/index.vue
@@ -58,6 +58,14 @@
               You will need to refresh the page to see this change applied.
             </p>
           </b-form-group>
+          <b-form-group
+            label="Highlight accepted nodes"
+            description="If enabled, accepted nodes will be highlighted in green."
+          >
+            <b-form-checkbox v-model="showAcceptedHighlight" switch>
+              {{ showAcceptedHighlight ? "Enabled" : "Disabled" }}
+            </b-form-checkbox>
+          </b-form-group>
           <b-form-group label="Default Depth" class="mb-0">
             <b-form-input
               v-model="defaultDepth"
@@ -298,6 +306,7 @@ export default {
       fileUploading: false,
       superuserOverridePermissions: true,
       showRejected: false,
+      showAcceptedHighlight: true,
       defaultDepth: 3,
       isExporting: false,
       renderImages: true,
@@ -368,6 +377,7 @@ export default {
         showAccess = true,
         superuserOverridePermissions = true,
         showRejected = false,
+        showAcceptedHighlight = true,
         defaultDepth = 3,
         renderImages = true,
         renderMap = false,
@@ -379,6 +389,7 @@ export default {
       this.showAccess = showAccess
       this.superuserOverridePermissions = superuserOverridePermissions
       this.showRejected = showRejected
+      this.showAcceptedHighlight = showAcceptedHighlight
       this.defaultDepth = defaultDepth
       this.renderImages = renderImages
       this.renderMap = renderMap
@@ -392,6 +403,7 @@ export default {
         showAccess: this.showAccess,
         superuserOverridePermissions: this.superuserOverridePermissions,
         showRejected: this.showRejected,
+        showAcceptedHighlight: this.showAcceptedHighlight,
         defaultDepth: parseInt(this.defaultDepth),
         renderImages: this.renderImages,
         renderMap: this.renderMap,


### PR DESCRIPTION
## Changes
* Add settings toggle to enable/disable accepted node highlighting
## Screenshot
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/45089842/104981760-15d6f780-59be-11eb-92ef-6934b611fd67.gif)
## Issue Linkage
Closes #934 
## PR Dependency
Depends on: N/A
## Automated Testing
* Renders node status bar based on showAcceptedHighlight state