### PR TITLE
935 - Bug Fix: User node permissions do not render

### DIFF
--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -138,8 +138,15 @@ class Tapestry implements ITapestry
     public function addNode($node)
     {
         $tapestryNode = new TapestryNode($this->postId);
-        $tapestryNode->set($node);
 
+        // Checks if user is logged in to prevent logged out user-0 from getting permissions
+        // Only add user permissions if it is not a review node
+        if (is_user_logged_in() && count($node->reviewComments) === 0) {
+            $userId = wp_get_current_user()->ID;
+            $node->permissions->{'user-'.$userId} = ['read', 'add', 'edit'];
+        }
+
+        $tapestryNode->set($node);
         $node = $tapestryNode->save($node);
 
         array_push($this->nodes, $node->id);

--- a/endpoints.php
+++ b/endpoints.php
@@ -700,10 +700,11 @@ function addTapestryLink($request)
             return $tapestry->addLink($link);
         }
         if (!TapestryHelpers::userIsAllowed('ADD', $link->source, $postId)) {
-            throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
+            throw new TapestryError('ADD_LINK_PERMISSION_DENIED');
         }
-        if (!TapestryHelpers::userIsAllowed('ADD', $link->target, $postId)) {
-            throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
+        if (!TapestryHelpers::userIsAllowed('ADD', $link->target, $postId)
+            && (!isset($link->addedOnNodeCreation) || !$link->addedOnNodeCreation)) {
+            throw new TapestryError('ADD_LINK_PERMISSION_DENIED');
         }
         $tapestry = new Tapestry($postId);
 
@@ -730,10 +731,10 @@ function deleteTapestryLink($request)
         }
         if (!TapestryHelpers::nodeIsDraft($link->target, $postId) && !TapestryHelpers::nodeIsDraft($link->source, $postId)) {
             if (!TapestryHelpers::userIsAllowed('ADD', $link->source, $postId)) {
-                throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
+                throw new TapestryError('DELETE_LINK_PERMISSION_DENIED');
             }
             if (!TapestryHelpers::userIsAllowed('ADD', $link->target, $postId)) {
-                throw new TapestryError('ADD_NODE_PERMISSION_DENIED');
+                throw new TapestryError('DELETE_LINK_PERMISSION_DENIED');
             }
         }
         $tapestry = new Tapestry($postId);

--- a/templates/vue/cypress/fixtures/subscriber-node.json
+++ b/templates/vue/cypress/fixtures/subscriber-node.json
@@ -1,0 +1,100 @@
+{
+  "nodes": [
+    {
+      "id": 2244,
+      "author": {
+        "id": "1",
+        "name": "admin"
+      },
+      "type": "tapestry_node",
+      "size": "",
+      "title": "Root",
+      "status": "publish",
+      "imageURL": "",
+      "lockedImageURL": "",
+      "mediaType": "text",
+      "mediaFormat": "",
+      "mediaDuration": 0,
+      "description": "qwe",
+      "behaviour": "embed",
+      "typeData": {
+        "linkMetadata": null,
+        "progress": [
+          {
+            "group": "viewed",
+            "value": 0,
+            "extra": {
+              "nodeType": "root",
+              "unlocked": true
+            }
+          },
+          {
+            "group": "unviewed",
+            "value": 1,
+            "extra": {
+              "nodeType": "root",
+              "unlocked": true
+            }
+          }
+        ],
+        "mediaURL": "",
+        "mediaWidth": 960,
+        "mediaHeight": 600,
+        "subAccordionText": "More content:",
+        "textContent": "qwe"
+      },
+      "coordinates": {
+        "x": 2939.49951171875,
+        "y": 3116.346923828125
+      },
+      "permissions": {
+        "public": [
+          "read"
+        ],
+        "authenticated": [
+          "read"
+        ],
+        "contributor": [
+          "read"
+        ],
+        "subscriber": [
+          "read",
+          "add",
+          "edit"
+        ]
+      },
+      "hideTitle": false,
+      "hideProgress": false,
+      "hideMedia": false,
+      "skippable": true,
+      "quiz": [],
+      "fullscreen": false,
+      "conditions": [],
+      "childOrdering": [],
+      "fitWindow": true,
+      "fx": 2939.49951171875,
+      "fy": 3116.346923828125,
+      "completed": false,
+      "accordionProgress": [],
+      "mayUnlockNodes": [],
+      "permissionsOrder": [
+        "public",
+        "authenticated",
+        "contributor",
+        "subscriber"
+      ],
+      "index": 0,
+      "x": 2939.49951171875,
+      "y": 3116.346923828125,
+      "vy": 0,
+      "vx": 0,
+      "nodeType": "root",
+      "unlocked": true,
+      "depth": 0,
+      "accessible": true
+    }
+  ],
+  "links": [],
+  "groups": [],
+  "site-url": "http://localhost:8000"
+}

--- a/templates/vue/cypress/integration/node-authoring.spec.js
+++ b/templates/vue/cypress/integration/node-authoring.spec.js
@@ -1,7 +1,10 @@
+import { roles } from "../support/roles"
+
 describe("Node Authoring", () => {
   beforeEach(() => {
     cy.fixture("one-node.json").as("oneNode")
     cy.fixture("two-nodes.json").as("twoNodes")
+    cy.fixture("subscriber-node.json").as("subscriberNode")
   })
 
   it("should be able to add a root node using the node modal", () => {
@@ -223,6 +226,42 @@ describe("Node Authoring", () => {
         cy.contains(/cancel/i).click()
         cy.contains(/close/i).click()
         cy.contains(`/${nodeName}/i`).should("not.exist")
+      })
+    })
+  })
+
+  describe("As subscriber:", () => {
+    beforeEach(() => {
+      cy.setup("@subscriberNode", roles.SUBSCRIBER)
+    })
+
+    it("should be able to add a child node using the node modal and edit as subscriber", () => {
+      const child = {
+        title: "Child 1",
+        mediaType: "text",
+        typeData: {
+          textContent: "Abcd",
+        },
+      }
+
+      cy.getSelectedNode().then(parent => {
+        cy.openModal("add", parent.id)
+        cy.getByTestId(`node-title`).type(child.title)
+
+        cy.changeMediaType(child.mediaType)
+        cy.getEditable(`node-text-content`).type(child.typeData.textContent)
+
+        cy.submitModal()
+        cy.contains(child.title).should("exist")
+        cy.getNodeByTitle(child.title)
+          .its("id")
+          .then(childId => {
+            cy.link(parent.id, childId).should("exist")
+            cy.getByTestId(`edit-node-${childId}`).click({ force: true })
+            cy.getByTestId("node-modal").should("be.visible")
+            cy.submitModal()
+            cy.getByTestId("node-modal").should("not.be.visible")
+          })
       })
     })
   })

--- a/templates/vue/src/components/modals/NodeModal/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/index.vue
@@ -442,13 +442,6 @@ export default {
         this.node.thumbnailFileId = fileId.data
       }
     })
-    this.node = this.createDefaultNode()
-    if (!this.node.mapCoordinates) {
-      this.node.mapCoordinates = {
-        lat: "",
-        lng: "",
-      }
-    }
     this.initialize()
   },
   methods: {
@@ -506,6 +499,12 @@ export default {
         copy = Helpers.deepCopy(node)
       }
       copy.hasSubAccordion = this.hasSubAccordion(copy)
+      if (!copy.mapCoordinates) {
+        copy.mapCoordinates = {
+          lat: "",
+          lng: "",
+        }
+      }
       this.node = copy
       this.setTapestryErrorReporting(false)
     },
@@ -651,6 +650,7 @@ export default {
             target: id,
             value: 1,
             type: "",
+            addedOnNodeCreation: true,
           }
           await this.addLink(newLink)
           // do not update parent's child ordering if the current node is a draft node since draft shouldn't appear in accordions

--- a/templates/vue/src/components/modals/common/PermissionsTable.spec.js
+++ b/templates/vue/src/components/modals/common/PermissionsTable.spec.js
@@ -1,0 +1,23 @@
+import { render } from "@/utils/test"
+import PermissionsTable from "./PermissionsTable.vue"
+
+describe("Permissions Table", () => {
+  it("should render public, authenticated, and user permissions", async () => {
+    const permissions = {
+      public: ["read"],
+      authenticated: ["read"],
+      "user-1": ["read", "add"],
+    }
+    const screen = render(PermissionsTable, {
+      props: { value: permissions },
+    })
+    for (const role of Object.keys(permissions)) {
+      await screen.findByText(new RegExp(role), "i")
+      for (const permission of permissions[role]) {
+        expect(
+          screen.getByTestId(`node-permissions-${role}-${permission}`)
+        ).toBeChecked()
+      }
+    }
+  })
+})

--- a/templates/vue/src/components/modals/common/PermissionsTable.vue
+++ b/templates/vue/src/components/modals/common/PermissionsTable.vue
@@ -77,6 +77,10 @@ export default {
           orderedPermissions.push([permission, this.value[higherPermission]])
         }
       })
+      const userPermissions = Object.entries(this.value).filter(
+        ([role, permissions]) => role.startsWith("user-") && permissions.length > 0
+      )
+      orderedPermissions.push(...userPermissions)
       return orderedPermissions
     },
   },
@@ -209,7 +213,8 @@ export default {
               higherRowPermissions.includes(type)
           )
           .forEach(type => newUserPermissions.push(type))
-        newPermissions[`user-${userId}`] = newUserPermissions
+        newPermissions[`user-${userId}`] =
+          newUserPermissions.length > 0 ? newUserPermissions : ["read"]
         this.userId = null
         this.$emit("input", newPermissions)
       } else {

--- a/templates/vue/src/store/actions.js
+++ b/templates/vue/src/store/actions.js
@@ -32,6 +32,7 @@ export async function addNode({ commit, dispatch, getters, state }, newNode) {
     const id = response.data.id
     nodeToAdd.id = id
     nodeToAdd.author = response.data.author
+    nodeToAdd.permissions = response.data.permissions
 
     commit("addNode", nodeToAdd)
     commit("updateVisibleNodes", [...state.visibleNodes, id])

--- a/utilities/class.tapestry-errors.php
+++ b/utilities/class.tapestry-errors.php
@@ -70,6 +70,14 @@ class TapestryError extends Error
             'MESSAGE' => 'You are not permitted to edit this node',
             'STATUS' => ['status' => 403],
         ],
+        'ADD_LINK_PERMISSION_DENIED' => [
+            'MESSAGE' => 'You are not permitted to add links to this node',
+            'STATUS' => ['status' => 403],
+        ],
+        'DELETE_LINK_PERMISSION_DENIED' => [
+            'MESSAGE' => 'You are not permitted to remove links from this node',
+            'STATUS' => ['status' => 403],
+        ],
         'EDIT_TAPESTRY_PERMISSION_DENIED' => [
             'MESSAGE' => 'You are not permitted to edit this tapestry',
             'STATUS' => ['status' => 403],

--- a/utilities/class.tapestry-helpers.php
+++ b/utilities/class.tapestry-helpers.php
@@ -219,6 +219,12 @@ class TapestryHelpers
         $groupIds = self::getGroupIdsOfUser($userId, $tapestryPostId);
         $user = new TapestryUser($userId);
 
+        // If node is submitted or accepted, users without edit access cannot edit node
+        $isEditableReviewStatus = isset($node->reviewStatus) && ($node->reviewStatus === "submitted" || $node->reviewStatus === "accepted");
+        if ($action === "EDIT" && $isEditableReviewStatus && !$user->canEdit($tapestryPostId)) {
+            return false;
+        }
+
         if ($user->canEdit($tapestryPostId) && $superuser_override) {
             return true;
         }


### PR DESCRIPTION
## Changes
* Update node permissions table to display users
## Issue Linkage
Closes #935 
## PR Dependency
Depends on: N/A
## Automated Testing
* Given public, authenticated, and user-1 permissions props, PermissionsTable renders checked boxes for the permissions.