### PR TITLE
941 - Bug fix: Can't see node permissions tab on any node in GEOG 498 tapestry

### DIFF
--- a/templates/vue/src/components/modals/common/PermissionsTable.vue
+++ b/templates/vue/src/components/modals/common/PermissionsTable.vue
@@ -71,10 +71,16 @@ export default {
       const orderedPermissions = []
       PERMISSIONS_ORDER.forEach((permission, index) => {
         if (this.value.hasOwnProperty(permission)) {
-          orderedPermissions.push([permission, this.value[permission]])
+          orderedPermissions.push([
+            permission,
+            this.value[permission] ? this.value[permission] : [],
+          ])
         } else {
           const higherPermission = PERMISSIONS_ORDER[index - 1]
-          orderedPermissions.push([permission, this.value[higherPermission]])
+          orderedPermissions.push([
+            permission,
+            this.value[higherPermission] ? this.value[higherPermission] : [],
+          ])
         }
       })
       return orderedPermissions


### PR DESCRIPTION
## Changes
* Checks permission value before adding the permissions to be rendered.
## Issue Linkage
Closes #941 
## PR Dependency
Depends on: N/A
## Automated Testing
* N/A
I'm unsure whether this is the cause of the bug as I have only replicated this issue in production and the log errors are similar to the errors displayed in #939 (Issue #935) when "public" and "authenticated" permissions are not passed in. Since you may not be able to replicate this error, please just review the code. The update handles the condition where "public" and "authenticated" have undefined permissions.