### PR TITLE
956 - Bug Fix: Prevent Console Error for Redundant / Duplicate Router Navigation

### DIFF
--- a/templates/vue/src/router.js
+++ b/templates/vue/src/router.js
@@ -20,6 +20,14 @@ const router = new VueRouter({
   routes,
 })
 
+// sourced from https://stackoverflow.com/questions/58634914/getting-navigation-duplicated-error-while-the-route-is-being-replaced-on-vue-rou
+const originalPush = VueRouter.prototype.push
+VueRouter.prototype.push = function push(location) {
+  return originalPush.call(this, location).catch(err => {
+    if (err.name !== "NavigationDuplicated") throw err
+  })
+}
+
 router.beforeEach((to, from, next) => {
   const nodes = Object.keys(store.state.nodes)
   if (to.matched.length === 0 && nodes.length > 0) {

--- a/templates/vue/src/router.js
+++ b/templates/vue/src/router.js
@@ -20,7 +20,7 @@ const router = new VueRouter({
   routes,
 })
 
-// sourced from https://stackoverflow.com/questions/58634914/getting-navigation-duplicated-error-while-the-route-is-being-replaced-on-vue-rou
+// sourced from https://stackoverflow.com/questions/58634914
 const originalPush = VueRouter.prototype.push
 VueRouter.prototype.push = function push(location) {
   return originalPush.call(this, location).catch(err => {


### PR DESCRIPTION
- overwrites the default router push function to catch duplicated navigation errors

Closes 956

Testing:
Console should no longer log router duplicate navigation errors (ex. when opening the settings and then closing it)
