### PR TITLE
958 -  Add Setting Toggles to Allow Draft Nodes and Submitting Nodes

### DIFF
--- a/classes/class.tapestry.php
+++ b/classes/class.tapestry.php
@@ -97,6 +97,10 @@ class Tapestry implements ITapestry
             if (!isset($this->settings->analyticsEnabled)) {
                 $this->settings->analyticsEnabled = false;
             }
+            if (!isset($this->settings->draftNodesEnabled)) {
+                $this->settings->draftNodesEnabled = true;
+                $this->settings->submitNodesEnabled = true;
+            }
         }
     }
 
@@ -474,6 +478,8 @@ class Tapestry implements ITapestry
         $settings->defaultPermissions = TapestryNodePermissions::getDefaultNodePermissions($this->postId);
         $settings->superuserOverridePermissions = true;
         $settings->analyticsEnabled = false;
+        $settings->draftNodesEnabled = true;
+        $settings->submitNodesEnabled = true;
         $settings->permalink = get_permalink($this->postId);
 
         return $settings;

--- a/templates/vue/cypress/integration/node-permissions.spec.js
+++ b/templates/vue/cypress/integration/node-permissions.spec.js
@@ -48,4 +48,39 @@ describe("Node Permissions", () => {
       cy.getByTestId(`add-node-${node.id}`).should("exist")
     })
   })
+
+  it("should not see add button or draft button if drafts disabled", () => {
+    cy.get(".settings-button").click()
+    cy.contains(/access/i).click()
+    cy.getByTestId(`enable-draft`).click({ force: true })
+    cy.submitSettingsModal()
+    cy.visitTapestry()
+    cy.getSelectedNode().then(node => {
+      cy.openModal("add", node.id)
+      cy.get("#draft-button").should("not.exist")
+    })
+    cy.logout()
+    cy.login("subscriber").visitTapestry()
+    cy.getSelectedNode().then(node => {
+      cy.getByTestId(`add-node-${node.id}`).should("not.exist")
+    })
+  })
+
+  it("should not see submit for review button if submit for review disabled", () => {
+    setup({
+      public: ["read"],
+      authenticated: ["read"],
+    })
+    cy.get(".settings-button").click()
+    cy.contains(/access/i).click()
+    cy.getByTestId(`enable-submit-review`).click({ force: true })
+    cy.submitSettingsModal()
+    cy.logout().visitTapestry()
+    cy.getSelectedNode().then(node => {
+      cy.login("subscriber").visitTapestry()
+      cy.openModal("add", node.id)
+      cy.getByTestId("submit-node-modal").should("not.exist")
+      cy.get("#draft-button").should("exist")
+    })
+  })
 })

--- a/templates/vue/src/components/Sidebar/NodeReview/index.vue
+++ b/templates/vue/src/components/Sidebar/NodeReview/index.vue
@@ -2,7 +2,9 @@
   <b-overlay class="loading" bg-color="#5d656c" :show="loading">
     <review-log :events="events" :aria-hidden="loading"></review-log>
     <div v-if="isReviewFormVisible" class="comment-form" :aria-hidden="loading">
-      <p class="commenter-name">{{ username }}</p>
+      <p class="commenter-name">
+        {{ username }}
+      </p>
       <textarea
         v-model="comment"
         aria-label="comment"
@@ -30,7 +32,7 @@
 </template>
 
 <script>
-import { mapActions } from "vuex"
+import { mapState, mapActions } from "vuex"
 
 import { nodeStatus } from "@/utils/constants"
 import * as Comment from "@/utils/comments"
@@ -57,6 +59,7 @@ export default {
     }
   },
   computed: {
+    ...mapState(["settings"]),
     events() {
       return this.node.reviewComments
     },
@@ -68,6 +71,8 @@ export default {
     isReviewFormVisible() {
       if (this.isReviewer) {
         return this.node.reviewStatus === nodeStatus.SUBMIT
+      } else if (!this.settings.submitNodesEnabled) {
+        return false
       }
       return this.node.status === nodeStatus.DRAFT
     },

--- a/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
+++ b/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
@@ -91,9 +91,7 @@
             <tapestry-icon :icon="icon" svg></tapestry-icon>
           </node-button>
           <template
-            v-if="
-              (isLoggedIn && this.settings.draftNodesEnabled) || hasPermission('add')
-            "
+            v-if="(isLoggedIn && this.settings.draftNodesEnabled) || canEditTapestry"
           >
             <add-child-button
               v-if="!isSubAccordionRow"
@@ -188,6 +186,9 @@ export default {
       "getParent",
       "isAccordionRow",
     ]),
+    canEditTapestry() {
+      return wp.canEditTapestry()
+    },
     canReview() {
       if (!this.isLoggedIn) {
         return false

--- a/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
+++ b/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
@@ -90,11 +90,12 @@
           >
             <tapestry-icon :icon="icon" svg></tapestry-icon>
           </node-button>
-          <template
-            v-if="(isLoggedIn && this.settings.draftNodesEnabled) || canEditTapestry"
-          >
+          <template v-if="isLoggedIn">
             <add-child-button
-              v-if="!isSubAccordionRow"
+              v-if="
+                !isSubAccordionRow &&
+                  (hasPermission('add') || this.settings.draftNodesEnabled)
+              "
               :node="node"
               :x="canReview || hasPermission('edit') ? -35 : 0"
               :y="radius"
@@ -186,9 +187,6 @@ export default {
       "getParent",
       "isAccordionRow",
     ]),
-    canEditTapestry() {
-      return wp.canEditTapestry()
-    },
     canReview() {
       if (!this.isLoggedIn) {
         return false

--- a/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
+++ b/templates/vue/src/components/TapestryMain/TapestryNode/index.vue
@@ -90,7 +90,11 @@
           >
             <tapestry-icon :icon="icon" svg></tapestry-icon>
           </node-button>
-          <template v-if="isLoggedIn">
+          <template
+            v-if="
+              (isLoggedIn && this.settings.draftNodesEnabled) || hasPermission('add')
+            "
+          >
             <add-child-button
               v-if="!isSubAccordionRow"
               :node="node"

--- a/templates/vue/src/components/Toolbar/index.vue
+++ b/templates/vue/src/components/Toolbar/index.vue
@@ -2,7 +2,7 @@
   <div class="toolbar">
     <tapestry-filter v-if="!showMap" style="z-index: 10;" />
     <div v-show="canEdit || (!showMap && hasDepth)" class="slider-wrapper">
-      <review-notifications v-if="canEdit" />
+      <review-notifications v-if="canEdit && settings.submitNodesEnabled" />
       <settings-modal-button
         v-if="canEdit"
         :max-depth="maxDepth"

--- a/templates/vue/src/components/modals/NodeModal/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/index.vue
@@ -155,7 +155,7 @@
               <span>Publish</span>
             </b-button>
             <b-button
-              v-else
+              v-else-if="this.settings.submitNodesEnabled"
               data-qa="submit-node-modal"
               size="sm"
               variant="primary"
@@ -627,6 +627,9 @@ export default {
       this.handleSubmit()
     },
     handleSubmitForReview() {
+      if (!this.settings.draftNodesEnabled || !this.settings.submitNodesEnabled) {
+        return
+      }
       this.node.reviewStatus = nodeStatus.SUBMIT
       this.node.status = nodeStatus.DRAFT
 
@@ -879,6 +882,9 @@ export default {
         : this.node.mediaURL !== mediaURL
     },
     hasDraftPermission(ID) {
+      if (!this.settings.draftNodesEnabled) {
+        return false
+      }
       if (ID === 0) {
         this.warningText = "You must be authenticated to create a draft node"
         return false

--- a/templates/vue/src/components/modals/SettingsModal/index.vue
+++ b/templates/vue/src/components/modals/SettingsModal/index.vue
@@ -245,7 +245,9 @@
           </b-form-group>
           <b-form-group
             label="Allow users to add draft nodes"
-            description="When enabled, users will be able to create draft nodes"
+            description="When enabled, users will be able to add draft nodes that are only visible to 
+              them to any node in the tapestry. These nodes will not be viewable by anyone else, 
+              including administrators."
           >
             <b-form-checkbox
               v-model="draftNodesEnabled"
@@ -259,7 +261,9 @@
           <b-form-group
             v-if="draftNodesEnabled"
             label="Allow users to submit draft nodes"
-            description="When enabled, users will be able to submit their nodes to administrators for review. Administrators can add a submitted node to the main tapestry by accepting the submission."
+            description="When enabled, users will be able to submit their nodes to administrators 
+              for review. Administrators can add a submitted node to the main tapestry by accepting 
+              the submission."
           >
             <b-form-checkbox
               v-model="submitNodesEnabled"

--- a/templates/vue/src/components/modals/SettingsModal/index.vue
+++ b/templates/vue/src/components/modals/SettingsModal/index.vue
@@ -245,7 +245,7 @@
           </b-form-group>
           <b-form-group
             label="Allow users to add draft nodes"
-            description="When enabled, users will be able to create draft nodes and optionally submit nodes for review"
+            description="When enabled, users will be able to create draft nodes"
           >
             <b-form-checkbox
               v-model="draftNodesEnabled"
@@ -255,14 +255,18 @@
             >
               {{ draftNodesEnabled ? "Enabled" : "Disabled" }}
             </b-form-checkbox>
+          </b-form-group>
+          <b-form-group
+            v-if="draftNodesEnabled"
+            label="Allow users to submit draft nodes"
+            description="When enabled, users will be able to submit their nodes to administrators for review. Administrators can add a submitted node to the main tapestry by accepting the submission."
+          >
             <b-form-checkbox
-              v-if="draftNodesEnabled"
               v-model="submitNodesEnabled"
               :data-qa="`enable-submit-review`"
               switch
             >
-              {{ submitNodesEnabled ? "Allow" : "Don't allow" }}
-              users to submit nodes for review
+              {{ submitNodesEnabled ? "Enabled" : "Disabled" }}
             </b-form-checkbox>
           </b-form-group>
         </b-tab>

--- a/templates/vue/src/components/modals/SettingsModal/index.vue
+++ b/templates/vue/src/components/modals/SettingsModal/index.vue
@@ -243,6 +243,22 @@
               {{ showAccess ? "Show" : "Hide" }}
             </b-form-checkbox>
           </b-form-group>
+          <b-form-group
+            label="Allow users to add draft nodes"
+            description="When enabled, users will be able to create draft nodes and optionally submit nodes for review"
+          >
+            <b-form-checkbox v-model="draftNodesEnabled" switch>
+              {{ draftNodesEnabled ? "Enabled" : "Disabled" }}
+            </b-form-checkbox>
+            <b-form-checkbox
+              v-if="draftNodesEnabled"
+              v-model="submitNodesEnabled"
+              switch
+            >
+              {{ submitNodesEnabled ? "Allow" : "Don't allow" }}
+              users to submit nodes for review
+            </b-form-checkbox>
+          </b-form-group>
         </b-tab>
       </b-tabs>
     </b-container>
@@ -320,6 +336,8 @@ export default {
       isExporting: false,
       renderImages: true,
       analyticsEnabled: false,
+      draftNodesEnabled: true,
+      submitNodesEnabled: true,
       renderMap: false,
       mapBounds: { neLat: 90, neLng: 180, swLat: -90, swLng: -180 },
       hasExported: false,
@@ -393,6 +411,8 @@ export default {
         renderImages = true,
         renderMap = false,
         analyticsEnabled = false,
+        draftNodesEnabled = true,
+        submitNodesEnabled = true,
         mapBounds = { neLat: 90, neLng: 180, swLat: -90, swLng: -180 },
       } = this.settings
       this.backgroundUrl = backgroundUrl
@@ -406,6 +426,8 @@ export default {
       this.renderImages = renderImages
       this.renderMap = renderMap
       this.analyticsEnabled = analyticsEnabled
+      this.draftNodesEnabled = draftNodesEnabled
+      this.submitNodesEnabled = submitNodesEnabled
       this.mapBounds = mapBounds
     },
     async updateSettings() {
@@ -421,6 +443,8 @@ export default {
         renderImages: this.renderImages,
         renderMap: this.renderMap,
         analyticsEnabled: this.analyticsEnabled,
+        draftNodesEnabled: this.draftNodesEnabled,
+        submitNodesEnabled: this.submitNodesEnabled,
         mapBounds: this.mapBounds,
       })
       await this.$store.dispatch("updateSettings", settings)

--- a/templates/vue/src/components/modals/SettingsModal/index.vue
+++ b/templates/vue/src/components/modals/SettingsModal/index.vue
@@ -247,12 +247,17 @@
             label="Allow users to add draft nodes"
             description="When enabled, users will be able to create draft nodes and optionally submit nodes for review"
           >
-            <b-form-checkbox v-model="draftNodesEnabled" switch>
+            <b-form-checkbox
+              v-model="draftNodesEnabled"
+              switch
+              :data-qa="`enable-draft`"
+            >
               {{ draftNodesEnabled ? "Enabled" : "Disabled" }}
             </b-form-checkbox>
             <b-form-checkbox
               v-if="draftNodesEnabled"
               v-model="submitNodesEnabled"
+              :data-qa="`enable-submit-review`"
               switch
             >
               {{ submitNodesEnabled ? "Allow" : "Don't allow" }}

--- a/templates/vue/src/components/modals/SettingsModal/index.vue
+++ b/templates/vue/src/components/modals/SettingsModal/index.vue
@@ -251,6 +251,7 @@
               v-model="draftNodesEnabled"
               switch
               :data-qa="`enable-draft`"
+              @change="handleSubmitNodesEnabled"
             >
               {{ draftNodesEnabled ? "Enabled" : "Disabled" }}
             </b-form-checkbox>
@@ -507,6 +508,9 @@ export default {
     },
     getCoord(coord, coordIfEmpty) {
       return coord === "" ? coordIfEmpty : coord
+    },
+    handleSubmitNodesEnabled(event) {
+      this.submitNodesEnabled = event
     },
   },
 }

--- a/templates/vue/src/utils/test.js
+++ b/templates/vue/src/utils/test.js
@@ -90,6 +90,8 @@ const mockSettings = {
   superuserOverridePermissions: true,
   permalink: "testing",
   showRejected: false,
+  draftNodesEnabled: true,
+  submitNodesEnabled: true,
 }
 
 function parseFixture(fixture, settings) {
@@ -100,5 +102,7 @@ function parseFixture(fixture, settings) {
     state.favourites = fixture.favourites || []
     return state
   }
-  return {}
+  return {
+    settings: { ...Helpers.deepCopy(mockSettings), ...settings },
+  }
 }


### PR DESCRIPTION
- Creates a toggle under settings->access to enable/disable users from creating draft nodes
- Creates a toggle under settings->access to enable/disable users from submitting their nodes for review (only visible if above toggle is enabled)
- When disabled, users should see buttons to save drafts/submit nodes for review

![image](https://user-images.githubusercontent.com/8981258/109886051-5f109d00-7c34-11eb-8ce6-8d659cb47ea1.png)

Closes #959

Automated Testing
- When drafts are disabled, create draft button is not visible and users without add permission cannot see the add button 
- When submit for review is disabled, users cannot see the button to submit drafts for review
