### PR TITLE
1024 - Hyperlinks don't update when editing multiple nodes

### DIFF
--- a/templates/vue/src/components/modals/NodeModal/forms/ContentForm/RichTextForm/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/forms/ContentForm/RichTextForm/index.vue
@@ -270,7 +270,7 @@ export default {
 
       if (mark && mark.attrs.href) {
         const presetURL = mark.attrs.href
-        prompt("Please update url:", presetURL) // let a user see the previously set URL
+        urlSetting = prompt("Please update url:", presetURL) // let a user see the previously set URL
       } else {
         urlSetting = prompt("Please add url:", "") // a clean prompt, has had no anchor
       }


### PR DESCRIPTION
## Changes
- Previous code didn't set the URL if it already existed.
- Setting the URL from the prompt to the current URL
## Screenshot

To see this problem at first you need to -
![Hyperlink-Update](https://user-images.githubusercontent.com/50620330/118841846-84996400-b87d-11eb-84c7-e2af1a2f8b54.gif)

1. Open a text form in a node (description or anything)
2. Set a URL for any text
3. Try to update the URL (Note that the URL prompt is different with "update" instead of "add")
4. Note the URL disappears completely and needs to be set again

## Issue Linkage
Closes (issue #1024 )
