### PR TITLE
1026 - Add new content type "Answer"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ cypress.json
 
 data/
 bin/config.sh
+
+vendor/

--- a/classes/class.tapestry-node.php
+++ b/classes/class.tapestry-node.php
@@ -38,6 +38,7 @@ class TapestryNode implements ITapestryNode
     private $hideMedia;
     private $skippable;
     private $quiz;
+    private $answer;
     private $fullscreen;
     private $childOrdering;
     private $fitWindow;
@@ -85,6 +86,7 @@ class TapestryNode implements ITapestryNode
         $this->hideMedia = false;
         $this->skippable = true;
         $this->quiz = [];
+        $this->answer = (object) [];
         $this->fullscreen = false;
         $this->childOrdering = [];
         $this->fitWindow = true;
@@ -203,6 +205,9 @@ class TapestryNode implements ITapestryNode
         }
         if (isset($node->quiz) && is_array($node->quiz)) {
             $this->quiz = $node->quiz;
+        }
+        if (isset($node->answer) && is_object($node->answer)) {
+            $this->answer = $node->answer;
         }
         if (isset($node->fullscreen) && is_bool($node->fullscreen)) {
             $this->fullscreen = $node->fullscreen;
@@ -557,6 +562,7 @@ class TapestryNode implements ITapestryNode
             'hideMedia' => $this->hideMedia,
             'skippable' => $this->skippable,
             'quiz' => $this->quiz,
+            'answer' => $this->answer,
             'fullscreen' => $this->fullscreen,
             'conditions' => $this->conditions,
             'childOrdering' => $this->childOrdering,

--- a/templates/vue/cypress/fixtures/answer.json
+++ b/templates/vue/cypress/fixtures/answer.json
@@ -1,0 +1,201 @@
+
+{
+    "nodes": [
+      {
+        "id": 7044,
+        "author": {
+          "id": "1",
+          "name": "admin"
+        },
+        "type": "tapestry_node",
+        "size": "",
+        "title": "Question Node",
+        "status": "publish",
+        "imageURL": "",
+        "lockedImageURL": "",
+        "mediaType": "question",
+        "mediaFormat": "",
+        "mediaDuration": 0,
+        "description": "",
+        "behaviour": "embed",
+        "typeData": {
+          "linkMetadata": null,
+          "progress": 0,
+          "mediaURL": "",
+          "mediaWidth": 960,
+          "mediaHeight": 600,
+          "subAccordionText": "More content:",
+          "textContent": ""
+        },
+        "coordinates": {
+          "x": 120.73933792114258,
+          "y": 2835.18701171875
+        },
+        "permissions": {
+          "public": [
+            "read"
+          ],
+          "authenticated": [
+            "read"
+          ],
+          "contributor": [
+            "read"
+          ],
+          "subscriber": [
+            "read"
+          ]
+        },
+        "hideTitle": false,
+        "hideProgress": false,
+        "hideMedia": false,
+        "skippable": true,
+        "quiz": [
+            {
+                "answers": {
+                    "audioId":"",
+                    "textId":"dac98d8f-948f-4733-9f38-f0d2f6233d2c"
+                },
+                "completed": true,
+                "entries": {
+                   "textId": {
+                    "dac98d8f-948f-4733-9f38-f0d2f6233d2c": "To do whatever."
+                   }
+                },
+                "followUpText": "Previously, you said:",
+                "id": "292f980b-a70b-4de6-880f-3dac55737ac6",
+                "isFollowUp": false,
+                "previousEntry": null,
+                "text": "What is the meaning of life?"
+            }
+        ],
+        "fullscreen": false,
+        "conditions": [],
+        "childOrdering": [],
+        "fitWindow": true,
+        "fx": 2939.49951171875,
+        "fy": 3116.346923828125,
+        "completed": false,
+        "accordionProgress": [],
+        "mayUnlockNodes": [],
+        "permissionsOrder": [
+          "public",
+          "authenticated",
+          "contributor",
+          "subscriber"
+        ],
+        "index": 0,
+        "x": 2939.49951171875,
+        "y": 3116.346923828125,
+        "vy": 0,
+        "vx": 0,
+        "nodeType": "root",
+        "unlocked": true,
+        "depth": 0,
+        "accessible": true
+      },
+      {
+        "id": 7045,
+        "author": {
+          "id": "1",
+          "name": "admin"
+        },
+        "type": "tapestry_node",
+        "size": "",
+        "title": "Another Question",
+        "status": "publish",
+        "imageURL": "",
+        "lockedImageURL": "",
+        "mediaType": "question",
+        "mediaFormat": "",
+        "mediaDuration": 0,
+        "description": "",
+        "behaviour": "embed",
+        "typeData": {
+          "linkMetadata": null,
+          "progress": 1,
+          "mediaURL": "",
+          "mediaWidth": 960,
+          "mediaHeight": 600,
+          "subAccordionText": "",
+          "textContent": ""
+        },
+        "coordinates": {
+          "x": -444.71843299984664,
+          "y": 3313.13887715537,
+          "fx": -359.76533851742477,
+          "fy": 2940.515586139745
+        },
+        "permissions": {
+          "public": [
+            "read"
+          ],
+          "authenticated": [
+            "read"
+          ],
+          "contributor": [
+            "read"
+          ],
+          "subscriber": [
+            "read"
+          ]
+        },
+        "hideTitle": false,
+        "hideProgress": false,
+        "hideMedia": false,
+        "skippable": true,
+        "quiz": [
+            {
+                "answers": {
+                    "audioId":"",
+                    "textId":"bd4e32c6-f8a0-45e8-bed4-281767a57459"
+                },
+                "completed": true,
+                "entries": {
+                   "textId": {
+                    "bd4e32c6-f8a0-45e8-bed4-281767a57459": "51"
+                   }
+                },
+                "followUpText": "Previously, you said:",
+                "id": "94f1da1d-6cb9-4c0d-9f7c-8b6521a31151",
+                "isFollowUp": false,
+                "previousEntry": null,
+                "text": "How many pigeons does it take to change a lightbulb?"
+            }
+        ],
+        "fullscreen": false,
+        "conditions": [],
+        "childOrdering": [],
+        "fitWindow": true,
+        "completed": true,
+        "accordionProgress": [],
+        "mayUnlockNodes": [],
+        "permissionsOrder": [
+          "public",
+          "authenticated",
+          "contributor",
+          "subscriber"
+        ],
+        "index": 0,
+        "x": 2939.49951171875,
+        "y": 3116.346923828125,
+        "vy": 0,
+        "vx": 0,
+        "nodeType": "child",
+        "unlocked": true,
+        "depth": 0,
+        "accessible": true
+      }
+    ],
+    "links": [
+        {
+            "source": 7044,
+            "target": 7045,
+            "value": 1,
+            "type": "",
+            "appearsAt": 0,
+            "index": 0
+        }
+    ],
+    "groups": [],
+    "site-url": "http://localhost:8000"
+  }

--- a/templates/vue/cypress/integration/lightbox/answer.spec.js
+++ b/templates/vue/cypress/integration/lightbox/answer.spec.js
@@ -1,0 +1,47 @@
+describe("Answers", () => {
+  it("should be able to create an Answer Node and display the correct answers", () => {
+    cy.fixture("answer.json").as("answers")
+    cy.setup("@answers")
+
+    const answerNode = {
+      title: "Answer Node",
+      mediaType: "answer",
+    }
+
+    cy.server()
+    cy.route("POST", `**/nodes`).as("addNode")
+    cy.route("PUT", `**/nodes/**`).as("editNode")
+
+    cy.getSelectedNode().then(node => {
+      cy.getByTestId(`add-node-${node.id}`).click()
+      cy.getByTestId(`node-title`).type(answerNode.title)
+      cy.getByTestId(`node-media-type`).select(answerNode.mediaType)
+      cy.getByTestId(`question-combobox`).within(() => {
+        cy.getByTestId(`choose-question-node`).click()
+        cy.contains(/What is the meaning of life?/i).should("be.visible")
+        cy.contains(/How many pigeons does it take to change a lightbulb?/i).should(
+          "be.visible"
+        )
+        cy.contains(/How many pigeons does it take to change a lightbulb?/i).click()
+      })
+
+      cy.getByTestId("follow-up-text").type("Your past answer: ")
+      cy.getByTestId("submit-node-modal").click()
+      cy.wait("@addNode")
+
+      cy.getNodeByTitle(answerNode.title).then(answer => {
+        cy.openLightbox(answer.id).within(() => {
+          cy.contains(answerNode.title).should("exist")
+          cy.contains(`How many pigeons does it take to change a lightbulb?`).should(
+            "be.visible"
+          )
+          cy.contains("Your past answer: ").should("be.visible")
+          cy.contains("51").should("be.visible")
+        })
+      })
+
+      cy.getByTestId("close-lightbox").click()
+    })
+    cy.lightbox().should("not.exist")
+  })
+})

--- a/templates/vue/src/components/Lightbox/media/AnswerMedia.vue
+++ b/templates/vue/src/components/Lightbox/media/AnswerMedia.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="answers">
+    <h1>{{ node.title }}</h1>
+    <div
+      v-if="answer !== null"
+      class="answer-container mx-auto mb-3"
+      data-qa="answer-display"
+    >
+      <h3>{{ question.text }}</h3>
+      <h4 v-if="followUpText" class="mb-4">
+        {{ answer.followUpText }}
+      </h4>
+      <h4 v-else class="mb-4">{{ question.followUpText }}</h4>
+      <tapestry-activity
+        v-for="questionAnswer in getAnswers"
+        :key="questionAnswer.type"
+        :type="questionAnswer.type"
+        :entry="questionAnswer.entry"
+      ></tapestry-activity>
+      <div v-show="getAnswers.length == 0">
+        You have not completed this question yet.
+      </div>
+    </div>
+    <div v-else>
+      <p>Please fill in the answer form.</p>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from "vuex"
+import TapestryActivity from "./common/ActivityScreen/TapestryActivity"
+export default {
+  name: "answer-media",
+  components: {
+    TapestryActivity,
+  },
+  props: {
+    node: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    ...mapGetters(["getEntry", "getQuestion"]),
+    answer() {
+      return this.node.answer
+    },
+    question() {
+      return this.getQuestion(this.answer.questionId)
+    },
+    followUpText() {
+      if (this.answer.followUpText !== "") {
+        return true
+      }
+      return false
+    },
+    getAnswers() {
+      try {
+        const answeredTypes = Object.entries(this.question.answers)
+          .filter(entry => entry[1] && entry[1].length > 0)
+          .map(i => i[0])
+        return answeredTypes
+          .map(type => this.getEntry(this.question.id, type, this.node.mediaType))
+          .filter(Boolean)
+      } catch (error) {
+        return []
+      }
+    },
+  },
+  mounted() {
+    this.$emit("complete")
+    this.$emit("load")
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.media-title {
+  text-align: left;
+  font-size: 1.75rem;
+  font-weight: 500;
+  margin-bottom: 0.9em;
+  :before {
+    display: none;
+  }
+}
+.answers {
+  color: white;
+}
+.answer-container {
+  width: 75%;
+}
+</style>

--- a/templates/vue/src/components/Lightbox/media/AnswerMedia.vue
+++ b/templates/vue/src/components/Lightbox/media/AnswerMedia.vue
@@ -7,16 +7,26 @@
       data-qa="answer-display"
     >
       <h3>{{ question.text }}</h3>
-      <h4 v-if="followUpText" class="mb-4">
+      <h4 v-show="followUpText && hasAnswer" class="mb-4">
         {{ answer.followUpText }}
       </h4>
-      <h4 v-else class="mb-4">{{ question.followUpText }}</h4>
-      <tapestry-activity
-        v-for="questionAnswer in getAnswers"
-        :key="questionAnswer.type"
-        :type="questionAnswer.type"
-        :entry="questionAnswer.entry"
-      ></tapestry-activity>
+      <h4 v-show="!followUpText && hasAnswer" class="mb-4">
+        {{ question.followUpText }}
+      </h4>
+      <b-tabs>
+        <b-tab v-for="questionAnswer in getAnswers" :key="questionAnswer.type">
+          <template #title>
+            <div class="icon">
+              <tapestry-icon :icon="questionAnswer.type" />
+              | {{ questionAnswer.type }}
+            </div>
+          </template>
+          <tapestry-activity
+            :type="questionAnswer.type"
+            :entry="questionAnswer.entry"
+          ></tapestry-activity>
+        </b-tab>
+      </b-tabs>
       <div v-show="getAnswers.length == 0">
         You have not completed this question yet.
       </div>
@@ -30,10 +40,12 @@
 <script>
 import { mapGetters } from "vuex"
 import TapestryActivity from "./common/ActivityScreen/TapestryActivity"
+import TapestryIcon from "@/components/common/TapestryIcon"
 export default {
   name: "answer-media",
   components: {
     TapestryActivity,
+    TapestryIcon,
   },
   props: {
     node: {
@@ -50,10 +62,7 @@ export default {
       return this.getQuestion(this.answer.questionId)
     },
     followUpText() {
-      if (this.answer.followUpText !== "") {
-        return true
-      }
-      return false
+      return this.answer.followUpText !== ""
     },
     getAnswers() {
       try {
@@ -66,6 +75,9 @@ export default {
       } catch (error) {
         return []
       }
+    },
+    hasAnswer() {
+      return this.getAnswers.length > 0
     },
   },
   mounted() {

--- a/templates/vue/src/components/Lightbox/media/AnswerMedia.vue
+++ b/templates/vue/src/components/Lightbox/media/AnswerMedia.vue
@@ -14,7 +14,11 @@
         {{ question.followUpText }}
       </h4>
       <b-tabs>
-        <b-tab v-for="questionAnswer in getAnswers" :key="questionAnswer.type">
+        <b-tab
+          v-for="questionAnswer in getAnswers"
+          :key="questionAnswer.type"
+          :active="questionAnswer.type === lastAnswerType"
+        >
           <template #title>
             <div class="icon">
               <tapestry-icon :icon="questionAnswer.type" />
@@ -41,6 +45,7 @@
 import { mapGetters } from "vuex"
 import TapestryActivity from "./common/ActivityScreen/TapestryActivity"
 import TapestryIcon from "@/components/common/TapestryIcon"
+
 export default {
   name: "answer-media",
   components: {
@@ -60,6 +65,9 @@ export default {
     },
     question() {
       return this.getQuestion(this.answer.questionId)
+    },
+    lastAnswerType() {
+      return this.question.lastAnswerType
     },
     followUpText() {
       return this.answer.followUpText !== ""
@@ -99,8 +107,10 @@ export default {
 }
 .answers {
   color: white;
+  margin-top: 15px;
 }
 .answer-container {
   width: 75%;
+  margin-top: 20px;
 }
 </style>

--- a/templates/vue/src/components/Lightbox/media/AnswerMedia.vue
+++ b/templates/vue/src/components/Lightbox/media/AnswerMedia.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="answers">
-    <h1>{{ node.title }}</h1>
+    <h3>{{ node.title }}</h3>
     <div
       v-if="answer !== null"
       class="answer-container mx-auto mb-3"
       data-qa="answer-display"
     >
-      <h3>{{ question.text }}</h3>
+      <h2>{{ question.text }}</h2>
       <h4 v-show="followUpText && hasAnswer" class="mb-4">
         {{ answer.followUpText }}
       </h4>
@@ -31,7 +31,7 @@
           ></tapestry-activity>
         </b-tab>
       </b-tabs>
-      <div v-show="getAnswers.length == 0">
+      <div v-show="!hasAnswer" class="media-wrapper">
         You have not completed this question yet.
       </div>
     </div>
@@ -96,15 +96,18 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.media-title {
-  text-align: left;
-  font-size: 1.75rem;
-  font-weight: 500;
-  margin-bottom: 0.9em;
-  :before {
-    display: none;
-  }
+.media-wrapper {
+  position: relative;
+  align-items: center;
+  background: #262626;
+  border-radius: 8px;
+  display: flex;
+  margin-bottom: 8px;
+  margin-top: 8px;
+  padding: 8px 16px 8px 38px;
+  justify-content: center;
 }
+
 .answers {
   color: white;
   margin-top: 15px;

--- a/templates/vue/src/components/Lightbox/media/TapestryMedia.vue
+++ b/templates/vue/src/components/Lightbox/media/TapestryMedia.vue
@@ -84,6 +84,14 @@
       @close="$emit('close')"
       @load="handleLoad"
     />
+    <answer-media
+      v-if="node.mediaType === 'answer'"
+      :node="node"
+      :context="context"
+      @complete="complete"
+      @close="$emit('close')"
+      @load="handleLoad"
+    />
     <completion-screen v-if="showCompletionScreen" />
   </div>
 </template>
@@ -99,6 +107,7 @@ import YouTubeMedia from "./YouTubeMedia"
 import WpPostMedia from "./WpPostMedia"
 import GravityForm from "./common/GravityForm"
 import CompletionScreen from "./common/ActivityScreen/CompletionScreen"
+import AnswerMedia from "./AnswerMedia"
 
 export default {
   name: "tapestry-media",
@@ -112,6 +121,7 @@ export default {
     CompletionScreen,
     ActivityMedia,
     "youtube-media": YouTubeMedia,
+    AnswerMedia,
   },
   props: {
     nodeId: {

--- a/templates/vue/src/components/Lightbox/media/common/ActivityScreen/Question.vue
+++ b/templates/vue/src/components/Lightbox/media/common/ActivityScreen/Question.vue
@@ -262,6 +262,7 @@ export default {
       client.recordAnalyticsEvent("user", "submit", "question", this.question.id, {
         type: type,
       })
+      this.question.lastAnswerType = type
       this.$emit("submit")
     },
   },

--- a/templates/vue/src/components/modals/NodeModal/forms/ContentForm/AnswerForm.vue
+++ b/templates/vue/src/components/modals/NodeModal/forms/ContentForm/AnswerForm.vue
@@ -1,0 +1,89 @@
+<template>
+  <div>
+    <b-form-group data-qa="question-combobox" label="Select a question:">
+      <combobox
+        v-model="questionId"
+        :options="questionOptions"
+        data-qa="choose-question-node"
+        item-text="text"
+        item-value="id"
+        empty-message="There are no questions yet."
+      >
+        <template v-slot="slotProps">
+          <p>
+            {{ slotProps.option.text }}
+          </p>
+        </template>
+      </combobox>
+    </b-form-group>
+    <b-form-group
+      label="Show this text first: "
+      description="If empty, will default to the follow-up text of the question form."
+    >
+      <b-form-input v-model="followUpText" data-qa="follow-up-text"></b-form-input>
+    </b-form-group>
+  </div>
+</template>
+
+<script>
+import { mapState } from "vuex"
+import Combobox from "@/components/modals/common/Combobox"
+export default {
+  components: {
+    Combobox,
+  },
+  props: {
+    node: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      questionId: "",
+      followUpText: "",
+    }
+  },
+  computed: {
+    ...mapState(["nodes"]),
+    questionOptions() {
+      let questions = Object.values(this.nodes)
+        .filter(node => Boolean(node.quiz))
+        .flatMap(node => node.quiz)
+      return questions
+    },
+  },
+  watch: {
+    followUpText(text) {
+      this.followUpText = text
+    },
+  },
+  mounted() {
+    this.questionId = this.initQuestionId()
+    this.followUpText = this.initFollowUpText()
+  },
+  updated() {
+    const answerObject = {
+      questionId: this.questionId,
+      followUpText: this.followUpText,
+    }
+    this.node.answer = answerObject
+  },
+  methods: {
+    initQuestionId() {
+      if (this.node.hasOwnProperty("answer")) {
+        return this.node.answer.questionId
+      }
+      return ""
+    },
+    initFollowUpText() {
+      if (this.node.hasOwnProperty("answer")) {
+        return this.node.answer.followUpText
+      }
+      return ""
+    },
+  },
+}
+</script>
+
+<style scoped></style>

--- a/templates/vue/src/components/modals/NodeModal/forms/ContentForm/QuestionForm.vue
+++ b/templates/vue/src/components/modals/NodeModal/forms/ContentForm/QuestionForm.vue
@@ -191,7 +191,7 @@ export default {
           text: "",
           answers: { ...defaultQuestion.answers },
           completed: false,
-          submissionTime: "",
+          lastAnswerType: "",
         },
       ]
       this.node.typeData = {

--- a/templates/vue/src/components/modals/NodeModal/forms/ContentForm/QuestionForm.vue
+++ b/templates/vue/src/components/modals/NodeModal/forms/ContentForm/QuestionForm.vue
@@ -191,6 +191,7 @@ export default {
           text: "",
           answers: { ...defaultQuestion.answers },
           completed: false,
+          submissionTime: "",
         },
       ]
       this.node.typeData = {

--- a/templates/vue/src/components/modals/NodeModal/forms/ContentForm/index.vue
+++ b/templates/vue/src/components/modals/NodeModal/forms/ContentForm/index.vue
@@ -96,6 +96,7 @@ import RichTextForm from "./RichTextForm"
 import UrlEmbedForm from "./UrlEmbedForm"
 import VideoForm from "./VideoForm"
 import WpPostForm from "./WpPostForm"
+import AnswerForm from "./AnswerForm"
 
 export default {
   components: {
@@ -109,6 +110,7 @@ export default {
     UrlEmbedForm,
     VideoForm,
     WpPostForm,
+    AnswerForm,
   },
   props: {
     parent: {
@@ -141,6 +143,10 @@ export default {
         { value: "url-embed", text: "External Link" },
         { value: "wp-post", text: "Wordpress Post" },
         { value: "question", text: "Question" },
+        {
+          label: "Advanced",
+          options: [{ value: "answer", text: "Answer" }],
+        },
         { value: "activity", text: "Activity" },
         { value: "gravity-form", text: "Gravity Form", disabled: true },
         { value: "multi-content", text: "Multi-Content" }, // must be last item

--- a/templates/vue/src/store/getters.js
+++ b/templates/vue/src/store/getters.js
@@ -129,7 +129,10 @@ export function getEntry(_, { getQuestion }) {
       return { type: "audio", entry: "data:audio/ogg; codecs=opus;base64," + entry }
     }
 
-    if (mediaType === "question" && answerType === "textId") {
+    if (
+      (mediaType === "question" || mediaType == "answer") &&
+      answerType === "textId"
+    ) {
       return {
         type: "text",
         entry: Object.values(entry)[0],


### PR DESCRIPTION
## Changes
- Adds the AnswerMedia and AnswerForm Vue components, creating the Answer Node type
- Adds Answer field to the Tapestry Node
- Allows users to select a question in the tapestry and displays the answer to it
- Allows users to change the follow-up text in the Answer node. If blank, will use the default follow-up text from the question node
- Added Cypress test to ensure basic functionality
## Screenshot
![](https://media.giphy.com/media/fkAOxqUFOie1AdQ5Je/giphy.gif)
## Issue Linkage
Closes #1026
## PR Dependency
Depends on #991 
## Automated Testing
- Can create a Question Node with one question and make an Answer Node displaying the answer to that question
- Can multiple Question Nodes with multiple questions and edit the Answer node form to display the answer to the selected question
- Will display a message stating that the question is not completed if it has not been answered yet
- The answer form will retain the previous entered information upon edit