### PR TITLE
1092 - TYDE 2 - Add ability to delete connections

### DIFF
--- a/classes/activities/class.circle-of-support.php
+++ b/classes/activities/class.circle-of-support.php
@@ -88,26 +88,22 @@ class CircleOfSupport
     
     public function deleteConnection($connectionId)
     {
-        if(!isset($this->current['connections']->$connectionId)){
+        if (!isset($this->current['connections']->$connectionId)) {
             return;
         }
-        
-        for ($i=0; $i < count($this->current['circles']) ; $i++) { 
+        for ($i=0; $i < count($this->current['circles']) ; $i++) {
             $this->removeConnectionFromCircle($i, $connectionId);
         }
 
-        foreach ($this->current['communities'] as $key => $value)
-        {
+        foreach ($this->current['communities'] as $key => $value) {
             /* removeConnectionFromCommunity checks whether the connection is
              * inside the community
              */
-            $this->removeConnectionFromCommunity($connectionId, $key);            
+            $this->removeConnectionFromCommunity($connectionId, $key);
         }
 
         
-        
         unset($this->current['connections']->$connectionId);
-
     }
 
     public function updateConnection($id, $connection)
@@ -211,12 +207,17 @@ class CircleOfSupport
         }
         
         $circle = $this->current['circles'][$circleIndex];
-        if(count($circle) == 0) {
+
+        if (count($circle) == 0) {
             return;
         }
 
         $index = array_search($connectionId, $circle);
         
+        if (!isset($index) || $index == null) {
+            return;
+        }
+              
         // This circle doesn't contain the connection
         if (!is_numeric($index)) {
             throw new TapestryError('CONNECTION_DOESNT_EXIST', sprintf("Circle %d doesn't contain connection %s", $circleIndex, $connectionId), 404);

--- a/classes/activities/class.circle-of-support.php
+++ b/classes/activities/class.circle-of-support.php
@@ -88,11 +88,14 @@ class CircleOfSupport
     
     public function deleteConnection($connectionId)
     {
+        if(!isset($this->current['connections']->$connectionId)){
+            return;
+        }
+        
         foreach ($this->current['communities'] as $key => $value)
         {
             $this->removeConnectionFromCommunity($connectionId, $key);            
         }
-        error_log(print_r($this->current['connections']->$connectionId,true));
         unset($this->current['connections']->$connectionId);
 
     }

--- a/classes/activities/class.circle-of-support.php
+++ b/classes/activities/class.circle-of-support.php
@@ -94,6 +94,9 @@ class CircleOfSupport
         
         foreach ($this->current['communities'] as $key => $value)
         {
+            /* removeConnectionFromCommunity checks whether the connection is
+             * inside the community
+             */
             $this->removeConnectionFromCommunity($connectionId, $key);            
         }
         unset($this->current['connections']->$connectionId);

--- a/classes/activities/class.circle-of-support.php
+++ b/classes/activities/class.circle-of-support.php
@@ -92,6 +92,10 @@ class CircleOfSupport
             return;
         }
         
+        for ($i=0; $i < count($this->current['circles']) ; $i++) { 
+            $this->removeConnectionFromCircle($i, $connectionId);
+        }
+
         foreach ($this->current['communities'] as $key => $value)
         {
             /* removeConnectionFromCommunity checks whether the connection is
@@ -99,6 +103,9 @@ class CircleOfSupport
              */
             $this->removeConnectionFromCommunity($connectionId, $key);            
         }
+
+        
+        
         unset($this->current['connections']->$connectionId);
 
     }
@@ -192,6 +199,7 @@ class CircleOfSupport
 
     public function removeConnectionFromCircle($circleIndex, $connectionId)
     {
+        
         // Check if circle exists
         if (!isset($this->current['circles'][$circleIndex])) {
             throw new TapestryError('CIRCLE_DOESNT_EXIST', sprintf('Cannot find circle with index %d', $circleIndex), 404);
@@ -201,18 +209,22 @@ class CircleOfSupport
         if (!isset($this->current['connections']->$connectionId)) {
             throw new TapestryError('CONNECTION_DOESNT_EXIST', sprintf('Cannot find connection with id %s', $connectionId), 404);
         }
-
+        
         $circle = $this->current['circles'][$circleIndex];
-        $index = array_search($connectionId, $circle);
+        if(count($circle) == 0) {
+            return;
+        }
 
+        $index = array_search($connectionId, $circle);
+        
         // This circle doesn't contain the connection
         if (!is_numeric($index)) {
             throw new TapestryError('CONNECTION_DOESNT_EXIST', sprintf("Circle %d doesn't contain connection %s", $circleIndex, $connectionId), 404);
         }
-
+        
         array_splice($circle, $index, 1);
         $this->current['circles'][$circleIndex] = $circle;
-
+        
         return $circle;
     }
 

--- a/classes/activities/class.circle-of-support.php
+++ b/classes/activities/class.circle-of-support.php
@@ -102,7 +102,6 @@ class CircleOfSupport
             $this->removeConnectionFromCommunity($connectionId, $key);
         }
 
-        
         unset($this->current['connections']->$connectionId);
     }
 
@@ -195,7 +194,6 @@ class CircleOfSupport
 
     public function removeConnectionFromCircle($circleIndex, $connectionId)
     {
-        
         // Check if circle exists
         if (!isset($this->current['circles'][$circleIndex])) {
             throw new TapestryError('CIRCLE_DOESNT_EXIST', sprintf('Cannot find circle with index %d', $circleIndex), 404);
@@ -205,7 +203,7 @@ class CircleOfSupport
         if (!isset($this->current['connections']->$connectionId)) {
             throw new TapestryError('CONNECTION_DOESNT_EXIST', sprintf('Cannot find connection with id %s', $connectionId), 404);
         }
-        
+
         $circle = $this->current['circles'][$circleIndex];
 
         if (count($circle) == 0) {
@@ -217,15 +215,15 @@ class CircleOfSupport
         if (!isset($index) || $index == null) {
             return;
         }
-              
+
         // This circle doesn't contain the connection
         if (!is_numeric($index)) {
             throw new TapestryError('CONNECTION_DOESNT_EXIST', sprintf("Circle %d doesn't contain connection %s", $circleIndex, $connectionId), 404);
         }
-        
+
         array_splice($circle, $index, 1);
         $this->current['circles'][$circleIndex] = $circle;
-        
+
         return $circle;
     }
 

--- a/classes/activities/class.circle-of-support.php
+++ b/classes/activities/class.circle-of-support.php
@@ -85,6 +85,17 @@ class CircleOfSupport
 
         return $community;
     }
+    
+    public function deleteConnection($connectionId)
+    {
+        foreach ($this->current['communities'] as $key => $value)
+        {
+            $this->removeConnectionFromCommunity($connectionId, $key);            
+        }
+        error_log(print_r($this->current['connections']->$connectionId,true));
+        unset($this->current['connections']->$connectionId);
+
+    }
 
     public function updateConnection($id, $connection)
     {

--- a/endpoints.php
+++ b/endpoints.php
@@ -358,6 +358,14 @@ $REST_API_ENDPOINTS = [
             'callback' => 'CircleOfSupportEndpoints::removeConnectionFromCircle'
         ]
     ],
+    'DELETE_COS_CONNECTION' => (object) [
+        'ROUTE' => '/activities/cos/connections/(?P<connectionId>[a-zA-Z0-9]+)',
+        'ARGUMENTS' => [
+            'methods' => $REST_API_DELETE_METHOD,
+            'callback' => 'CircleOfSupportEndpoints::deleteConnection'
+        ]
+    ],
+    
 ];
 
 /*

--- a/endpoints/endpoints.circle-of-support.php
+++ b/endpoints/endpoints.circle-of-support.php
@@ -109,4 +109,18 @@ class CircleOfSupportEndpoints
             return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
         }
     }
+
+    public static function deleteConnection($request)
+    {
+        try {
+            $connectionId = $request['connectionId'];
+            
+            $cos = new CircleOfSupport();
+            $cos->deleteConnection($connectionId);
+            $cos->save();
+            return $connectionId;
+        } catch (TapestryError $e) {
+            return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
+        }
+    }
 }

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/CircleView/index.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/CircleView/index.vue
@@ -10,6 +10,7 @@
       @add-connection="$emit('add-connection', $event)"
       @edit-connection="handleEditConnection"
       @add-community="$emit('add-community', $event)"
+      @delete-connection="$emit('delete-connection', $event)"
       @drag:start="handleDragStart"
       @drag:move="handleDragMove"
       @drag:end="handleDragEnd"

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/CommunityView/index.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/CommunityView/index.vue
@@ -14,6 +14,7 @@
       @back="handleBack"
       @add-connection="$emit('add-connection', $event)"
       @edit-connection="handleEditConnection"
+      @delete-connection="$emit('delete-connection', $event)"
       @add-community="$emit('add-community', $event)"
     />
     <add-community-tab

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/ConnectionsTab/AddConnectionForm.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/ConnectionsTab/AddConnectionForm.vue
@@ -31,6 +31,9 @@
         </div>
         <div class="controls">
           <button @click="$emit('back')">Cancel</button>
+          <b-button v-if="connection.id" variant="danger" @click="handleDelete">
+            Delete connection
+          </b-button>
           <button
             class="submit"
             :disabled="validationState"
@@ -198,6 +201,11 @@ export default {
     handleAddCommunity(community) {
       this.$emit("add-community", community)
       this.showCommunityForm = false
+    },
+    handleDelete() {
+      if (confirm("Are you sure you want to delete this connection?")) {
+        this.$emit("delete", this.connection.id)
+      }
     },
   },
 }

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/ConnectionsTab/AddConnectionForm.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/ConnectionsTab/AddConnectionForm.vue
@@ -31,7 +31,12 @@
         </div>
         <div class="controls">
           <button @click="$emit('back')">Cancel</button>
-          <b-button v-if="connection.id" variant="danger" @click="handleDelete">
+          <b-button
+            v-if="connection.id"
+            tag="div"
+            variant="danger"
+            @click="handleDelete"
+          >
             Delete connection
           </b-button>
           <button

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/ConnectionsTab/index.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/ConnectionsTab/index.vue
@@ -14,6 +14,7 @@
           :communities="communities"
           @back="back"
           @submit="handleSubmit"
+          @delete="handleDelete"
           @add-community="$emit('add-community', $event)"
         />
       </b-overlay>
@@ -150,6 +151,16 @@ export default {
 
       this.isSubmitting = false
       this.resetConnection()
+      this.state = States.Home
+    },
+    async handleDelete(connectionId) {
+      this.isSubmitting = true
+
+      await client.cos.deleteConnection(connectionId)
+
+      this.$emit("delete-connection", connectionId)
+
+      this.isSubmitting = false
       this.state = States.Home
     },
     async addNewConnection() {

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
@@ -117,17 +117,19 @@ export default {
       const community = this.cos.communities[communityId]
       community.connections = community.connections.filter(id => id !== connectionId)
     },
-    handleDeleteConnection(connectionId) {
+    async handleDeleteConnection(connectionId) {
       delete this.cos.connections[connectionId]
 
       Object.values(this.cos.communities).forEach(community => {
         this.removeConnectionFromCommunity(community.id, connectionId)
       })
 
-      this.cos.circles.forEach((circle, index) => {
-        const connectionIndex = circle.indexOf(connectionId)
-        delete this.cos.circles[index][connectionIndex]
+      const newCircles = []
+      this.cos.circles.forEach(circle => {
+        const newCircle = circle.filter(connection => connection !== connectionId)
+        newCircles.push(newCircle)
       })
+      this.cos.circles = newCircles
     },
   },
 }

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
@@ -18,6 +18,7 @@
         :communities="cos.communities"
         @add-connection="addConnection"
         @edit-connection="editConnection"
+        @delete-connection="handleDeleteConnection"
         @add-community="addCommunity"
       />
       <div class="switch">
@@ -121,6 +122,11 @@ export default {
 
       Object.values(this.cos.communities).forEach(community => {
         this.removeConnectionFromCommunity(community.id, connectionId)
+      })
+
+      this.cos.circles.forEach((circle, index) => {
+        const connectionIndex = circle.indexOf(connectionId)
+        delete this.cos.circles[index][connectionIndex]
       })
     },
   },

--- a/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
+++ b/templates/vue/src/components/tyde/activities/CircleOfSupport/index.vue
@@ -8,6 +8,7 @@
         :communities="cos.communities"
         @add-connection="addConnection"
         @edit-connection="editConnection"
+        @delete-connection="handleDeleteConnection"
         @add-community="addCommunity"
       />
       <circle-view
@@ -114,6 +115,13 @@ export default {
     removeConnectionFromCommunity(communityId, connectionId) {
       const community = this.cos.communities[communityId]
       community.connections = community.connections.filter(id => id !== connectionId)
+    },
+    handleDeleteConnection(connectionId) {
+      delete this.cos.connections[connectionId]
+
+      Object.values(this.cos.communities).forEach(community => {
+        this.removeConnectionFromCommunity(community.id, connectionId)
+      })
     },
   },
 }

--- a/templates/vue/src/services/TapestryAPI.js
+++ b/templates/vue/src/services/TapestryAPI.js
@@ -319,6 +319,11 @@ class TapestryApi {
           .post(`${baseUrl}/circles/${circleIndex}`, { id: connectionId })
           .then(res => res.data)
       },
+      deleteConnection(connectionId) {
+        return client
+          .delete(`${baseUrl}/connections/${connectionId}`)
+          .then(res => res.data)
+      },
       removeConnectionFromCircle(circleIndex, connectionId) {
         return client
           .delete(`${baseUrl}/circles/${circleIndex}/connections/${connectionId}`)


### PR DESCRIPTION
## Task Description
When editing a connection, show a Delete button

When connection is deleted, delete that connection from all communities and circles as well.

## Changes

- Add back end functionality to delete a connection in endpoins, endpoins.circle-of-support, and class.circle-of-support
- Add front end functionality to delete a connection only if the connection already exists.

## Issue Linkage
Closes (issue #1092 )
## PR Dependency
Depends on: (PR #1047 )
## Automated Testing
* No automated testing for TYDE 
