### PR TITLE
1074 - Save the last selected node for user and select it on load (using router hook)

### DIFF
--- a/classes/class.tapestry-user-progress.php
+++ b/classes/class.tapestry-user-progress.php
@@ -132,25 +132,25 @@ class TapestryUserProgress implements ITapestryUserProgress
     }
 
     /**
-     * This function checks if any user has answered a question
+     * This function checks if any user has answered a question.
      *
-     * @param string $postId 
-     * @param string $nodeMetaId 
-     * @param string $questionId 
-     * 
-     * @return boolean $hasAnswer
+     * @param string $postId
+     * @param string $nodeMetaId
+     * @param string $questionId
+     *
+     * @return bool $hasAnswer
      */
     public static function questionsHasAnyAnswer($postId, $nodeMetaId, $questionId, $answerType)
     {
-        $userIds = get_users(array('fields'=> array('ID')));
+        $userIds = get_users(['fields' => ['ID']]);
         $hasAnswer = false;
-    
-        foreach($userIds as $userId) {
-           $user_answer = get_user_meta($userId->ID, 'tapestry_'.$postId.'_'.$nodeMetaId.'_question_'.$questionId.'_answers', true);
-           if($user_answer != '' && is_array($user_answer) && array_key_exists($answerType, $user_answer)) {
-               $hasAnswer = true;
-               break;
-           }
+
+        foreach ($userIds as $userId) {
+            $user_answer = get_user_meta($userId->ID, 'tapestry_'.$postId.'_'.$nodeMetaId.'_question_'.$questionId.'_answers', true);
+            if ('' != $user_answer && is_array($user_answer) && array_key_exists($answerType, $user_answer)) {
+                $hasAnswer = true;
+                break;
+            }
         }
 
         return $hasAnswer;
@@ -270,6 +270,45 @@ class TapestryUserProgress implements ITapestryUserProgress
     {
         $this->_checkPostId();
         update_user_meta($this->_userId, 'tapestry_favourites_'.$this->postId, $favourites);
+    }
+
+    /**
+     * Get User's last selected node for a tapestry post.
+     *
+     * @return int $nodeId  node id of the last selected node in the tapestry
+     */
+    public function getLastSelectedNode()
+    {
+        $this->_isValidTapestryPost();
+        $this->_checkPostId();
+
+        $lastSelectedNode = get_user_meta($this->_userId, 'tapestry_last_selected_node_'.$this->postId, true);
+
+        return $lastSelectedNode;
+    }
+
+    /**
+     * Update User's last selected node for a tapestry post.
+     *
+     * @param int $nodeId node id of the last selected node in the tapestry
+     *
+     * @return null
+     */
+    public function updateLastSelectedNode($nodeId, $rowId, $subRowId)
+    {
+        $this->_checkPostId();
+
+        $lastSelectedNode = new stdClass();
+        $lastSelectedNode->nodeId = $nodeId;
+
+        if ($rowId) {
+            $lastSelectedNode->rowId = $rowId;
+        }
+        if ($subRowId) {
+            $lastSelectedNode->subRowId = $subRowId;
+        }
+
+        update_user_meta($this->_userId, 'tapestry_last_selected_node_'.$this->postId, $lastSelectedNode);
     }
 
     /* Helpers */

--- a/endpoints.php
+++ b/endpoints.php
@@ -248,6 +248,20 @@ $REST_API_ENDPOINTS = [
             'callback' => 'updateUserFavourites',
         ],
     ],
+    'GET_TAPESTRY_USER_LAST_SELECTED_NODE' => (object) [
+            'ROUTE' => 'users/lastSelectedNode',
+            'ARGUMENTS' => [
+                'methods' => $REST_API_GET_METHOD,
+                'callback' => 'getLastSelectedNode',
+        ],
+    ],
+    'UPDATE_TAPESTRY_USER_LAST_SELECTED_NODE' => (object) [
+        'ROUTE' => 'users/lastSelectedNode',
+        'ARGUMENTS' => [
+            'methods' => $REST_API_POST_METHOD,
+            'callback' => 'updateLastSelectedNode',
+        ],
+    ],
     'LOGIN' => (object) [
         'ROUTE' => '/login',
         'ARGUMENTS' => [
@@ -1391,6 +1405,41 @@ function updateUserFavourites($request)
         $userProgress = new TapestryUserProgress($postId);
 
         return $userProgress->updateFavourites($favourites);
+    } catch (TapestryError $e) {
+        return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
+    }
+}
+
+/**
+ * Get User's last selected node for a tapestry post.
+ *
+ * @return int $nodeId  node id of the last selected node in the tapestry
+ */
+function getLastSelectedNode($request)
+{
+    $postId = $request['post_id'];
+    try {
+        $userProgress = new TapestryUserProgress($postId);
+
+        return $userProgress->getLastSelectedNode();
+    } catch (TapestryError $e) {
+        return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
+    }
+}
+
+/**
+ * Update last selected node for the current user by passing in post id and node id
+ *
+ * @param object $request HTTP request
+ */
+function updateLastSelectedNode($request)
+{
+    $postId = $request['post_id'];
+    $body = json_decode($request->get_body());
+    try {
+        $userProgress = new TapestryUserProgress($postId);
+
+        return $userProgress->updateLastSelectedNode($body->nodeId, $body->rowId, $body->subRowId);
     } catch (TapestryError $e) {
         return new WP_Error($e->getCode(), $e->getMessage(), $e->getStatus());
     }

--- a/interfaces/interface.tapestry-user-progress.php
+++ b/interfaces/interface.tapestry-user-progress.php
@@ -71,4 +71,20 @@ interface ITapestryUserProgress
      * @return null
      */
     public function updateFavourites($favourites);
+
+    /**
+     * Get User's last selected node for a tapestry post.
+     *
+     * @return int $nodeId  node id of the last selected node in the tapestry
+     */
+    public function getLastSelectedNode();
+
+    /**
+     * Update User's last selected node for a tapestry post.
+     *
+     * @param int $nodeId node id of the last selected node in the tapestry
+     *
+     * @return null
+     */
+    public function updateLastSelectedNode($nodeId, $rowId, $subRowId);
 }

--- a/templates/vue/src/App.vue
+++ b/templates/vue/src/App.vue
@@ -73,13 +73,27 @@ export default {
     }
 
     window.addEventListener("click", this.recordAnalytics)
-    const data = [client.getTapestry(), client.getUserProgress()]
-    Promise.all(data).then(([dataset, progress]) => {
+    const data = [
+      client.getTapestry(),
+      client.getUserProgress(),
+      client.getLastSelectedNode(),
+    ]
+    Promise.all(data).then(([dataset, progress, selectedNode]) => {
       this.init({ dataset, progress })
       this.loading = false
       if (!this.$route.params.nodeId && dataset.nodes.length > 0) {
+        let path = `/nodes/${dataset.rootId}`
+        if (selectedNode) {
+          path = `/nodes/${selectedNode.nodeId}`
+          if (selectedNode.rowId) {
+            path = `${path}/view/${selectedNode.rowId}`
+            if (selectedNode.subRowId) {
+              path = `${path}/rows/${selectedNode.subRowId}`
+            }
+          }
+        }
         this.$router.replace({
-          path: `/nodes/${dataset.rootId}`,
+          path,
           query: this.$route.query,
         })
       }

--- a/templates/vue/src/router.js
+++ b/templates/vue/src/router.js
@@ -1,5 +1,6 @@
 import Vue from "vue"
 import VueRouter from "vue-router"
+import client from "./services/TapestryAPI"
 
 import routeConfig, { names } from "./config/routes"
 import store from "./store"
@@ -36,6 +37,28 @@ router.beforeEach((to, from, next) => {
     next({ name: names.APP, params: { nodeId: store.state.rootId } })
   } else {
     next()
+  }
+})
+
+let userLastSelectedNodeTimeout = null
+
+router.afterEach((to, from) => {
+  if (
+    from.matched.length > 0 &&
+    to.matched.length > 0 &&
+    (from.params.nodeId !== to.params.nodeId ||
+      from.params.rowId !== to.params.rowId ||
+      from.query.row !== to.query.row ||
+      from.params.subRowId !== to.params.subRowId)
+  ) {
+    clearTimeout(userLastSelectedNodeTimeout)
+    userLastSelectedNodeTimeout = setTimeout(() => {
+      client.updateUserLastSelectedNode(
+        to.params.nodeId,
+        to.params.rowId ? to.params.rowId : to.query.row,
+        to.params.subRowId
+      )
+    }, 5000)
   }
 })
 

--- a/templates/vue/src/services/TapestryAPI.js
+++ b/templates/vue/src/services/TapestryAPI.js
@@ -230,6 +230,23 @@ class TapestryApi {
     return response
   }
 
+  async getLastSelectedNode() {
+    const url = `/users/lastSelectedNode?post_id=${this.postId}`
+    const response = await this.client.get(url)
+    return response.data
+  }
+
+  async updateUserLastSelectedNode(nodeId, rowId, subRowId) {
+    const url = `/users/lastSelectedNode?post_id=${this.postId}`
+    const response = await this.client.post(url, {
+      post_id: this.postId,
+      nodeId,
+      rowId,
+      subRowId,
+    })
+    return response
+  }
+
   async getAllContributors() {
     const url = `/tapestries/${this.postId}/contributors`
     const response = await this.client.get(url)


### PR DESCRIPTION
## Changes
- When Tapestry loads, the selected node is the user's last selected node rather than the root node
- If the user is not logged in, the last selected node will be the root node

Note: This PR is a rewrite of #1076 that uses a router hook for saving the selected node
## Issue Linkage
Closes #1074
## PR Dependency
Depends on #1066 
## Automated Testing
N/A
