### PR TITLE
1119 - Activities do not fit the lightbox on tyde2

### DIFF
--- a/templates/vue/src/components/Lightbox/media/TapestryMedia.vue
+++ b/templates/vue/src/components/Lightbox/media/TapestryMedia.vue
@@ -159,6 +159,7 @@ export default {
   border-radius: 15px;
   overflow: auto;
   height: 100%;
+  width: 100%;
   padding: 0;
 
   &-no-scroll {


### PR DESCRIPTION
## Changes
Sets the media-wrapper div to have width:100%
## Issue Linkage
Closes (issue #1119 )
## PR Dependency
Depends on: (N/A)

