### PR TITLE
1129 - Optimize and bring consistency to activity and answer UI

### DIFF
--- a/templates/vue/src/components/Lightbox/media/ActivityMedia/AnswerMedia.vue
+++ b/templates/vue/src/components/Lightbox/media/ActivityMedia/AnswerMedia.vue
@@ -1,25 +1,31 @@
 <template>
-  <div class="answers">
-    <h3>{{ node.title }}</h3>
-    <div class="answer-container mx-auto mb-3" data-qa="answer-display">
-      <h4>{{ answersTypeData.precedingText || question.text }}</h4>
-      <b-tabs vertical no-nav-style nav-class="nav-tablist">
-        <b-tab v-for="questionAnswer in answers" :key="questionAnswer[0]">
-          <template #title>
-            <div class="icon">
-              <tapestry-icon :icon="getIcon(questionAnswer[0])" />
-            </div>
-          </template>
-          <completed-activity-media
-            :type="questionAnswer[0]"
-            :answerData="questionAnswer[1]"
-            :question="question"
-          ></completed-activity-media>
-        </b-tab>
-      </b-tabs>
-      <div v-show="!hasAnswer" class="media-wrapper">
-        You have not completed this question yet.
-      </div>
+  <div class="answer-container mx-auto mb-3" data-qa="answer-display">
+    <h1 class="question-title">
+      {{ answersTypeData.precedingText || question.text }}
+    </h1>
+    <b-tabs v-if="answers.length > 1" vertical no-nav-style nav-class="nav-tablist">
+      <b-tab v-for="questionAnswer in answers" :key="questionAnswer[0]">
+        <template #title>
+          <div class="icon">
+            <tapestry-icon :icon="getIcon(questionAnswer[0])" />
+          </div>
+        </template>
+        <completed-activity-media
+          :type="questionAnswer[0]"
+          :answerData="questionAnswer[1]"
+          :question="question"
+        ></completed-activity-media>
+      </b-tab>
+    </b-tabs>
+    <div v-else>
+      <completed-activity-media
+        :type="answers[0][0]"
+        :answerData="answers[0][1]"
+        :question="question"
+      ></completed-activity-media>
+    </div>
+    <div v-show="!hasAnswer" class="p-2 my-4">
+      <em>You have not completed this question yet.</em>
     </div>
   </div>
 </template>
@@ -90,23 +96,24 @@ export default {
 }
 </style>
 <style lang="scss" scoped>
-.media-wrapper {
-  position: relative;
-  align-items: center;
-  border-radius: 8px;
-  display: flex;
-  margin-bottom: 8px;
-  margin-top: 8px;
-  padding: 8px 16px 8px 38px;
-  justify-content: center;
-}
-.answers {
-  color: #111;
-  margin-top: 15px;
-  width: 100%;
-}
 .answer-container {
-  width: 75%;
-  margin-top: 20px;
+  color: #111;
+  width: 100%;
+  margin-top: 16px;
+
+  @media screen and (min-width: 1000px) {
+    width: 75%;
+  }
+
+  .question-title {
+    position: relative;
+    font-size: 28px;
+    font-weight: 600 !important;
+    margin-top: 4px;
+
+    &:before {
+      display: none;
+    }
+  }
 }
 </style>

--- a/templates/vue/src/components/Lightbox/media/ActivityMedia/Question/DragDropQuestion/Item.vue
+++ b/templates/vue/src/components/Lightbox/media/ActivityMedia/Question/DragDropQuestion/Item.vue
@@ -68,7 +68,7 @@ export default {
   background-position: center;
   background-repeat: no-repeat;
   text-align: center;
-  padding: 40px 0;
+  padding: 10px 0;
   margin: auto;
 }
 </style>

--- a/templates/vue/src/components/Lightbox/media/ActivityMedia/index.vue
+++ b/templates/vue/src/components/Lightbox/media/ActivityMedia/index.vue
@@ -15,8 +15,14 @@
         <p>Next question</p>
       </button>
       <button v-else class="button-completion" @click="close">
-        <i class="far fa-times-circle fa-4x"></i>
-        <p>Done</p>
+        <template v-if="context === 'lightbox'">
+          <i class="fas fa-times-circle fa-4x"></i>
+          <p>Done</p>
+        </template>
+        <template v-else>
+          <i class="fas fa-arrow-circle-right fa-4x"></i>
+          <p>Continue</p>
+        </template>
       </button>
     </completion-screen>
     <question

--- a/templates/vue/src/components/Lightbox/media/common/CompletedActivityMedia/DragDrop/Bucket.vue
+++ b/templates/vue/src/components/Lightbox/media/common/CompletedActivityMedia/DragDrop/Bucket.vue
@@ -40,7 +40,6 @@ export default {
   color: #555;
   display: inline-flex;
   flex-direction: column;
-  min-height: 250px;
   border-radius: 15px;
   overflow-wrap: break-word;
 }

--- a/templates/vue/src/components/Lightbox/media/common/CompletedActivityMedia/DragDrop/Item.vue
+++ b/templates/vue/src/components/Lightbox/media/common/CompletedActivityMedia/DragDrop/Item.vue
@@ -46,7 +46,7 @@ export default {
   background-position: center;
   background-repeat: no-repeat;
   text-align: center;
-  padding: 40px 0;
+  padding: 10px 0;
   margin: auto;
 }
 </style>

--- a/templates/vue/src/components/Lightbox/media/common/CompletedActivityMedia/index.vue
+++ b/templates/vue/src/components/Lightbox/media/common/CompletedActivityMedia/index.vue
@@ -7,7 +7,13 @@
         </div>
       </b-col>
       <b-col v-if="type === 'text' && isListTextType">
-        <ol>
+        <ol
+          :class="{
+            text:
+              answerData.length === 1 &&
+              !question.answerTypes.multipleChoice.useImages,
+          }"
+        >
           <li v-for="answer in answerData" :key="answer.index">
             {{ answer }}
           </li>
@@ -23,7 +29,13 @@
         />
       </b-col>
       <b-col v-if="type === 'multipleChoice'" align-self="center">
-        <ul>
+        <ul
+          :class="{
+            text:
+              answerData.length === 1 &&
+              !question.answerTypes.multipleChoice.useImages,
+          }"
+        >
           <li v-for="answer in answerData" :key="answer.index">
             <completed-multiple-choice-item
               :item="getMultipleChoiceAnswerItem(answer)"
@@ -91,9 +103,13 @@ export default {
   margin-bottom: 8px;
   padding: 8px 16px 8px 16px;
   .text {
-    text-align: left;
-    padding-left: 1em;
-    border-left: solid 1px #666;
+    padding: 0.5em 1em;
+    background: #ffffff6b;
+    display: inline-flex;
+    border-radius: 5px;
+    box-shadow: 0 0 5px inset #0000003b;
+    margin: 0;
+    list-style-type: none;
   }
 }
 </style>


### PR DESCRIPTION
Currently, there's quite a bit of inconsistency in the way we display activities and answers. There's also been some feedback around this, so we want to improve the activity UI accordingly.
## Changes
* Make the styling of Answer and Activity more consistent
* Remove double placement of answer heading in mutli-content child nodes
* Hide answer tabs if there's only one answer type
* Maximize the usage of space, especially for drag and drop
* Reduce the height of drag and drop items
* Change "Done" with (X) icon to "Continue" in multi-content child nodes so it's more clear
* If there's a single text-only answer in a multiple choice or list, view it the same as a text entry 
## Screenshot
* TBC
## Issue Linkage
Closes #1129 
## PR Dependency
N/A
## Automated Testing
N/A
